### PR TITLE
Add Timebox view with day/week calendar scheduling

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,3 +14,6 @@ STRIPE_PREMIUM_PRICE_ID=price_...
 
 # Frontend URL for Stripe redirect (default: http://localhost:3000)
 FRONTEND_URL=http://localhost:3000
+
+# Admin secret key - set this to bypass Stripe and manually set user tiers
+ADMIN_SECRET_KEY=change-me-to-something-secret

--- a/backend/app.py
+++ b/backend/app.py
@@ -688,6 +688,31 @@ def health():
     return jsonify({'status': 'ok'})
 
 
+# === Admin endpoint (no Stripe required) ===
+@app.route('/api/admin/set-tier', methods=['POST'])
+def admin_set_tier():
+    admin_key = os.getenv('ADMIN_SECRET_KEY')
+    if not admin_key:
+        return jsonify({'error': 'Admin access not configured'}), 403
+
+    data = request.json or {}
+    if data.get('admin_key') != admin_key:
+        return jsonify({'error': 'Invalid admin key'}), 403
+
+    email = data.get('email', '').strip().lower()
+    tier = data.get('tier', 'premium')
+    if tier not in TIERS:
+        return jsonify({'error': f'Invalid tier. Choose: {list(TIERS.keys())}'}), 400
+
+    user = User.query.filter_by(email=email).first()
+    if not user:
+        return jsonify({'error': f'No user found with email: {email}'}), 404
+
+    user.tier = tier
+    db.session.commit()
+    return jsonify({'ok': True, 'email': user.email, 'tier': user.tier})
+
+
 def migrate_db():
     with app.app_context():
         with db.engine.connect() as conn:

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import text
 from flask_jwt_extended import (
     JWTManager, create_access_token, jwt_required, get_jwt_identity
 )
@@ -104,6 +105,9 @@ class Task(db.Model):
     position = db.Column(db.Integer, default=0)
     subtasks = db.Column(db.Text, default='[]')   # JSON: [{id, text, done}]
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    duration = db.Column(db.Integer, default=30)           # minutes
+    scheduled_time = db.Column(db.String(5), nullable=True)  # HH:MM
+    scheduled_date = db.Column(db.String(10), nullable=True) # YYYY-MM-DD
 
     def subtasks_list(self):
         try:
@@ -122,6 +126,9 @@ class Task(db.Model):
             'due': self.due,
             'position': self.position,
             'subtasks': self.subtasks_list(),
+            'duration': self.duration if self.duration is not None else 30,
+            'scheduled_time': self.scheduled_time,
+            'scheduled_date': self.scheduled_date,
         }
 
 
@@ -447,6 +454,12 @@ def update_task(task_id):
             task.hat_id = None
     if 'subtasks' in data:
         task.subtasks = json.dumps(data['subtasks'])
+    if 'duration' in data:
+        task.duration = int(data['duration']) if data['duration'] else 30
+    if 'scheduled_time' in data:
+        task.scheduled_time = data['scheduled_time'] or None
+    if 'scheduled_date' in data:
+        task.scheduled_date = data['scheduled_date'] or None
 
     db.session.commit()
     return jsonify(task.to_dict())
@@ -675,7 +688,23 @@ def health():
     return jsonify({'status': 'ok'})
 
 
+def migrate_db():
+    with app.app_context():
+        with db.engine.connect() as conn:
+            for stmt in [
+                'ALTER TABLE task ADD COLUMN duration INTEGER DEFAULT 30',
+                'ALTER TABLE task ADD COLUMN scheduled_time VARCHAR(5)',
+                'ALTER TABLE task ADD COLUMN scheduled_date VARCHAR(10)',
+            ]:
+                try:
+                    conn.execute(text(stmt))
+                except Exception:
+                    pass  # column already exists
+            conn.commit()
+
+
 if __name__ == '__main__':
     with app.app_context():
         db.create_all()
+    migrate_db()
     app.run(debug=True, port=5001)

--- a/backend/app.py
+++ b/backend/app.py
@@ -406,6 +406,9 @@ def add_task():
                 recurring=data.get('recurring', '').strip(),
                 due=data.get('due', '') or None,
                 position=next_pos,
+                duration=int(data['duration']) if data.get('duration') else 30,
+                scheduled_time=data.get('scheduled_time') or None,
+                scheduled_date=data.get('scheduled_date') or None,
             )
             db.session.add(task)
             all_tasks.append(task)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import Header from './components/Header';
 import Stats from './components/Stats';
 import HatBar from './components/HatBar';
 import CategorySection from './components/CategorySection';
+import TimeboxView from './components/TimeboxView';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import PricingPage from './pages/PricingPage';
@@ -436,6 +437,9 @@ function TaskApp() {
           <button className={`view-btn ${viewMode === 'categories' ? 'active' : ''}`} onClick={() => setViewMode('categories')}>
             By Category
           </button>
+          <button className={`view-btn ${viewMode === 'timebox' ? 'active' : ''}`} onClick={() => setViewMode('timebox')}>
+            Timebox
+          </button>
         </div>
 
         {viewMode === 'active' && (
@@ -487,6 +491,13 @@ function TaskApp() {
             onAddTask={addTask}
             categoryOrder={categoryOrder}
             onReorderCategories={saveCategoryOrder}
+          />
+        )}
+
+        {viewMode === 'timebox' && (
+          <TimeboxView
+            tasks={getVisibleTasks()}
+            onUpdate={updateTask}
           />
         )}
       </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -498,6 +498,7 @@ function TaskApp() {
           <TimeboxView
             tasks={getVisibleTasks()}
             onUpdate={updateTask}
+            onAddTask={addTask}
           />
         )}
       </div>

--- a/frontend/src/components/TimeboxView.css
+++ b/frontend/src/components/TimeboxView.css
@@ -1,0 +1,459 @@
+/* ── Container ─────────────────────────────────────────────────────────────── */
+.timebox-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* ── Sub-view toggle ───────────────────────────────────────────────────────── */
+.timebox-subview-toggle {
+  display: inline-flex;
+  gap: 3px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  align-self: flex-start;
+}
+
+.timebox-sub-btn {
+  padding: 6px 18px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+
+.timebox-sub-btn:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.timebox-sub-btn.active {
+  background: rgba(255, 255, 255, 0.14);
+  color: white;
+  font-weight: 600;
+}
+
+/* ── Week wrapper ──────────────────────────────────────────────────────────── */
+.timebox-week-wrapper {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+}
+
+.timebox-week-wrapper::-webkit-scrollbar { height: 4px; }
+.timebox-week-wrapper::-webkit-scrollbar-track { background: transparent; }
+.timebox-week-wrapper::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 2px; }
+
+/* ── Day column ────────────────────────────────────────────────────────────── */
+.timebox-day-column {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.timebox-day-column.week-col {
+  min-width: 180px;
+  max-width: 260px;
+}
+
+/* ── Column header ─────────────────────────────────────────────────────────── */
+.timebox-col-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.timebox-col-header.today {
+  border-color: rgba(102, 126, 234, 0.4);
+  background: rgba(102, 126, 234, 0.1);
+}
+
+.timebox-col-date {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.timebox-col-header.today .timebox-col-date {
+  color: #a5b4fc;
+}
+
+.timebox-col-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.timebox-mit-count {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.timebox-auto-btn {
+  padding: 5px 11px;
+  border: 1px solid rgba(102, 126, 234, 0.4);
+  border-radius: 8px;
+  background: rgba(102, 126, 234, 0.15);
+  color: #a5b4fc;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+.timebox-auto-btn:hover {
+  background: rgba(102, 126, 234, 0.28);
+  border-color: rgba(102, 126, 234, 0.65);
+}
+
+/* ── Grid wrapper ──────────────────────────────────────────────────────────── */
+.timebox-grid-wrapper {
+  position: relative;
+  height: 520px;
+  overflow-y: auto;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(12px);
+}
+
+.timebox-grid-wrapper::-webkit-scrollbar { width: 4px; }
+.timebox-grid-wrapper::-webkit-scrollbar-track { background: transparent; }
+.timebox-grid-wrapper::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.12); border-radius: 2px; }
+
+/* ── Grid canvas ───────────────────────────────────────────────────────────── */
+.timebox-grid {
+  position: relative;
+  user-select: none;
+  cursor: crosshair;
+}
+
+/* ── Hour labels + lines ───────────────────────────────────────────────────── */
+.timebox-hour-label {
+  position: absolute;
+  left: 0;
+  width: 36px;
+  text-align: right;
+  padding-right: 8px;
+  font-size: 10px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.25);
+  transform: translateY(-6px);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.timebox-hour-line {
+  position: absolute;
+  left: 36px;
+  right: 0;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.07);
+  pointer-events: none;
+}
+
+.timebox-halfhour-line {
+  position: absolute;
+  left: 36px;
+  right: 0;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.03);
+  border-top: 1px dashed rgba(255, 255, 255, 0.04);
+  pointer-events: none;
+}
+
+/* ── Inactive overlays ─────────────────────────────────────────────────────── */
+.timebox-inactive {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.28);
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* ── Window bars ───────────────────────────────────────────────────────────── */
+.window-bar {
+  position: absolute;
+  left: 36px;
+  right: 0;
+  height: 3px;
+  cursor: ns-resize;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+}
+
+.window-bar--start {
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  box-shadow: 0 0 8px rgba(102, 126, 234, 0.5);
+}
+
+.window-bar--end {
+  background: linear-gradient(90deg, #764ba2, #667eea);
+  box-shadow: 0 0 8px rgba(102, 126, 234, 0.5);
+}
+
+.window-bar-label {
+  position: absolute;
+  left: 6px;
+  background: rgba(30, 27, 58, 0.92);
+  border: 1px solid rgba(102, 126, 234, 0.5);
+  color: #a5b4fc;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 20px;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+/* ── Blocked time ──────────────────────────────────────────────────────────── */
+.timebox-blocked {
+  position: absolute;
+  left: 36px;
+  right: 0;
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.04) 4px,
+    rgba(255, 255, 255, 0.01) 4px,
+    rgba(255, 255, 255, 0.01) 10px
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  z-index: 4;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+}
+
+.timebox-blocked:hover {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(248, 113, 113, 0.08),
+    rgba(248, 113, 113, 0.08) 4px,
+    rgba(248, 113, 113, 0.03) 4px,
+    rgba(248, 113, 113, 0.03) 10px
+  );
+  border-color: rgba(248, 113, 113, 0.3);
+}
+
+.timebox-blocked--preview {
+  pointer-events: none;
+  border-color: rgba(102, 126, 234, 0.3);
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(102, 126, 234, 0.07),
+    rgba(102, 126, 234, 0.07) 4px,
+    rgba(102, 126, 234, 0.02) 4px,
+    rgba(102, 126, 234, 0.02) 10px
+  );
+}
+
+.timebox-blocked-label {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.3);
+  padding: 0 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+}
+
+/* ── Task blocks ───────────────────────────────────────────────────────────── */
+.timebox-task {
+  position: absolute;
+  left: 40px;
+  right: 4px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.09);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-left: 3px solid rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(8px);
+  cursor: grab;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: box-shadow 0.1s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+
+.timebox-task:active { cursor: grabbing; box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4); }
+
+/* Priority border colors */
+.timebox-task.priority-urgent { border-left-color: #f87171; background: rgba(248, 113, 113, 0.1); }
+.timebox-task.priority-today  { border-left-color: #fbbf24; background: rgba(251, 191, 36, 0.08); }
+.timebox-task.priority-tomorrow { border-left-color: #60a5fa; background: rgba(96, 165, 250, 0.08); }
+.timebox-task.priority-later { border-left-color: rgba(255, 255, 255, 0.15); }
+
+/* MIT override */
+.timebox-task.mit {
+  border-left-color: #fbbf24 !important;
+  background: rgba(251, 191, 36, 0.15) !important;
+  border-color: rgba(251, 191, 36, 0.35);
+  box-shadow: 0 2px 12px rgba(251, 191, 36, 0.2);
+}
+
+.timebox-task-body {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 3px 6px;
+  gap: 4px;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.timebox-task-desc {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.88);
+  line-height: 1.3;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  flex: 1;
+}
+
+.timebox-task-meta {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.timebox-task-duration {
+  font-size: 9px;
+  color: rgba(255, 255, 255, 0.35);
+  white-space: nowrap;
+}
+
+/* Resize handles */
+.timebox-task-resize-top,
+.timebox-task-resize-bottom {
+  height: 6px;
+  width: 100%;
+  cursor: ns-resize;
+  flex-shrink: 0;
+  z-index: 6;
+}
+
+.timebox-task-resize-top:hover,
+.timebox-task-resize-bottom:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* ── MIT button ────────────────────────────────────────────────────────────── */
+.timebox-mit-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 10px;
+  padding: 1px 2px;
+  border-radius: 3px;
+  opacity: 0.35;
+  transition: opacity 0.15s;
+  line-height: 1;
+}
+
+.timebox-mit-btn:hover { opacity: 0.75; }
+.timebox-mit-btn.active { opacity: 1; }
+.timebox-mit-btn.disabled { opacity: 0.15; cursor: not-allowed; }
+
+/* ── Unscheduled panel ─────────────────────────────────────────────────────── */
+.timebox-unscheduled {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.timebox-unscheduled-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 13px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  transition: color 0.15s;
+}
+
+.timebox-unscheduled-toggle:hover { color: rgba(255, 255, 255, 0.8); }
+
+.timebox-unscheduled-count {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 10px;
+  padding: 1px 7px;
+  border-radius: 20px;
+}
+
+.timebox-unscheduled-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 10px 10px;
+}
+
+.timebox-unscheduled-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 9px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  border-left: 2px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-left-width: 2px;
+}
+
+.timebox-unscheduled-chip.priority-urgent { border-left-color: #f87171; }
+.timebox-unscheduled-chip.priority-today  { border-left-color: #fbbf24; }
+.timebox-unscheduled-chip.priority-tomorrow { border-left-color: #60a5fa; }
+.timebox-unscheduled-chip.mit {
+  border-left-color: #fbbf24 !important;
+  background: rgba(251, 191, 36, 0.1);
+}
+
+.timebox-chip-desc {
+  flex: 1;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.78);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timebox-chip-dur {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.3);
+  white-space: nowrap;
+}

--- a/frontend/src/components/TimeboxView.css
+++ b/frontend/src/components/TimeboxView.css
@@ -457,3 +457,132 @@
   color: rgba(255, 255, 255, 0.3);
   white-space: nowrap;
 }
+
+/* ── Slot popup ────────────────────────────────────────────────────────────── */
+.slot-popup-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+
+.slot-popup {
+  position: fixed;
+  z-index: 1000;
+  width: 240px;
+  background: #1e1b3a;
+  border: 1px solid rgba(102, 126, 234, 0.35);
+  border-radius: 14px;
+  padding: 14px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.slot-popup-time {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  font-weight: 600;
+  color: #a5b4fc;
+}
+
+.slot-popup-dur {
+  font-size: 11px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.07);
+  padding: 2px 7px;
+  border-radius: 20px;
+}
+
+.slot-popup-input {
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 13px;
+  padding: 8px 10px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.slot-popup-input:focus {
+  border-color: rgba(102, 126, 234, 0.6);
+}
+
+.slot-popup-input::placeholder {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.slot-popup-priority {
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 12px;
+  padding: 6px 8px;
+  font-family: inherit;
+  outline: none;
+  cursor: pointer;
+}
+
+.slot-popup-priority option {
+  background: #1e1b3a;
+}
+
+.slot-popup-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.slot-popup-btn {
+  flex: 1;
+  padding: 7px 6px;
+  border-radius: 8px;
+  border: none;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.15s;
+}
+
+.slot-popup-btn--task {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+}
+
+.slot-popup-btn--task:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.slot-popup-btn--task:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.slot-popup-btn--block {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.slot-popup-btn--block:hover {
+  background: rgba(255, 255, 255, 0.13);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.slot-popup-btn--cancel {
+  background: none;
+  color: rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  flex: 0 0 auto;
+  padding: 7px 10px;
+}
+
+.slot-popup-btn--cancel:hover {
+  color: rgba(255, 255, 255, 0.6);
+}

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -272,7 +272,7 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
         setLocalTasks(prev => prev.map(t => t.id === dragging.taskId ? { ...t, scheduled_time: formatTime(newStartMin), duration: newDur } : t));
       }
     };
-    const onUp = async () => {
+    const onUp = async (e) => {
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
       if (dragging.type === 'window-start' || dragging.type === 'window-end') {
@@ -280,9 +280,16 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
       } else if (dragging.type === 'task-move' || dragging.type === 'task-resize-bottom' || dragging.type === 'task-resize-top') {
         const updated = localTasks.find(t => t.id === dragging.taskId);
         if (updated) {
+          // Detect cross-day drop by checking which day column is under the cursor
+          let targetDate = date;
+          if (dragging.type === 'task-move') {
+            const el = document.elementFromPoint(e.clientX, e.clientY);
+            const col = el?.closest('[data-date]');
+            if (col) targetDate = col.getAttribute('data-date');
+          }
           await onUpdateTask(updated.id, {
             scheduled_time: updated.scheduled_time,
-            scheduled_date: updated.scheduled_date || date,
+            scheduled_date: targetDate,
             duration: updated.duration,
           });
         }
@@ -356,7 +363,7 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
   const isToday = date === new Date().toISOString().split('T')[0];
 
   return (
-    <div className={`timebox-day-column ${isWeekView ? 'week-col' : ''}`}>
+    <div className={`timebox-day-column ${isWeekView ? 'week-col' : ''}`} data-date={date}>
       {/* Column header */}
       <div className={`timebox-col-header ${isToday ? 'today' : ''}`}>
         <div className="timebox-col-date">{formatDateLabel(date)}</div>

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -102,14 +102,99 @@ function loadMit() {
 }
 function saveMit(ids) { localStorage.setItem('ztd_mit_tasks', JSON.stringify([...ids])); }
 
+// ── Slot popup (shown after grid drag) ───────────────────────────────────────
+function SlotPopup({ slot, date, onAddTask, onBlockTime, onCancel }) {
+  const [desc, setDesc] = useState('');
+  const [priority, setPriority] = useState('');
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    setTimeout(() => inputRef.current?.focus(), 30);
+  }, []);
+
+  const duration = slot.endMin - slot.startMin;
+
+  const handleAddTask = async () => {
+    if (!desc.trim()) return;
+    await onAddTask({
+      description: desc.trim(),
+      priority,
+      duration,
+      scheduled_time: formatTime(slot.startMin),
+      scheduled_date: date,
+      due: date,
+    });
+    onCancel();
+  };
+
+  const handleBlockTime = () => {
+    onBlockTime(slot.startMin, slot.endMin);
+    onCancel();
+  };
+
+  // Clamp popup to viewport
+  const popupTop = Math.min(slot.screenY, window.innerHeight - 220);
+  const popupLeft = Math.min(slot.screenX + 12, window.innerWidth - 260);
+
+  return (
+    <>
+      <div className="slot-popup-backdrop" onClick={onCancel} />
+      <div className="slot-popup" style={{ top: popupTop, left: popupLeft }}>
+        <div className="slot-popup-time">
+          {formatTime(slot.startMin)} – {formatTime(slot.endMin)}
+          <span className="slot-popup-dur">{duration}m</span>
+        </div>
+        <input
+          ref={inputRef}
+          className="slot-popup-input"
+          placeholder="Task name…"
+          value={desc}
+          onChange={e => setDesc(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') handleAddTask();
+            if (e.key === 'Escape') onCancel();
+          }}
+        />
+        <select
+          className="slot-popup-priority"
+          value={priority}
+          onChange={e => setPriority(e.target.value)}
+        >
+          <option value="">No priority</option>
+          <option value="urgent">Urgent</option>
+          <option value="today">Today</option>
+          <option value="tomorrow">Tomorrow</option>
+          <option value="later">Later</option>
+        </select>
+        <div className="slot-popup-actions">
+          <button
+            className="slot-popup-btn slot-popup-btn--task"
+            onClick={handleAddTask}
+            disabled={!desc.trim()}
+          >
+            + Add Task
+          </button>
+          <button className="slot-popup-btn slot-popup-btn--block" onClick={handleBlockTime}>
+            Block Time
+          </button>
+          <button className="slot-popup-btn slot-popup-btn--cancel" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
 // ── TimeboxDayColumn ─────────────────────────────────────────────────────────
-function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes, onBlockedTimesChange, mitIds, onToggleMit, onUpdateTask, isWeekView, shuffleSeed, onShuffle }) {
+function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes, onBlockedTimesChange, mitIds, onToggleMit, onUpdateTask, onAddTask, isWeekView, shuffleSeed, onShuffle }) {
   const gridRef = useRef(null);
   const wrapperRef = useRef(null);
-  const [dragging, setDragging] = useState(null); // { type, taskId, startY, startVal }
+  const [dragging, setDragging] = useState(null);
   const [localTasks, setLocalTasks] = useState(tasks);
   const [localWindow, setLocalWindow] = useState(dayWindow);
-  const [blockDrag, setBlockDrag] = useState(null); // { startMin, endMin }
+  const [blockDrag, setBlockDrag] = useState(null); // { startMin, endMin, screenX, screenY }
+  const [pendingSlot, setPendingSlot] = useState(null); // shown after drag ends
   const [unscheduledOpen, setUnscheduledOpen] = useState(true);
 
   useEffect(() => { setLocalTasks(tasks); }, [tasks]);
@@ -133,17 +218,14 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
 
   // ── Auto-schedule ──────────────────────────────────────────────────────────
   const handleAutoSchedule = useCallback(async () => {
-    onShuffle(); // increment seed
+    onShuffle();
     const PRIO = PRIORITY_ORDER;
     let ordered = [...columnTasks].sort((a, b) => (PRIO[a.priority] ?? 4) - (PRIO[b.priority] ?? 4));
-
-    // shuffle using current seed + 1 (seed was just incremented)
     const seed = shuffleSeed + 1;
     for (let i = ordered.length - 1; i > 0; i--) {
       const j = Math.floor(seededRandom(seed + i) * (i + 1));
       [ordered[i], ordered[j]] = [ordered[j], ordered[i]];
     }
-
     let cursor = windowStart;
     const updates = [];
     for (const task of ordered) {
@@ -153,16 +235,13 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
       updates.push({ id: task.id, scheduled_time: formatTime(cursor), scheduled_date: date });
       cursor += dur;
     }
-
-    // optimistic update
     const updatedMap = {};
     updates.forEach(u => { updatedMap[u.id] = u; });
     setLocalTasks(prev => prev.map(t => updatedMap[t.id] ? { ...t, ...updatedMap[t.id] } : t));
-
     await Promise.all(updates.map(u => onUpdateTask(u.id, { scheduled_time: u.scheduled_time, scheduled_date: u.scheduled_date })));
   }, [columnTasks, blockedTimes, date, windowStart, windowEnd, shuffleSeed, onShuffle, onUpdateTask]);
 
-  // ── Mouse drag helpers ─────────────────────────────────────────────────────
+  // ── Task / window drag ─────────────────────────────────────────────────────
   const startMouseDrag = useCallback((type, extra, e) => {
     e.preventDefault();
     e.stopPropagation();
@@ -171,11 +250,9 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
 
   useEffect(() => {
     if (!dragging) return;
-
     const onMove = (e) => {
       const deltaY = e.clientY - dragging.startY;
       const deltaMins = yToMinutes(deltaY);
-
       if (dragging.type === 'window-start') {
         const newMin = Math.max(0, Math.min(windowEnd - 60, snapMinutes(dragging.origMin + deltaMins)));
         setLocalWindow(w => ({ ...w, start: formatTime(newMin) }));
@@ -195,11 +272,9 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
         setLocalTasks(prev => prev.map(t => t.id === dragging.taskId ? { ...t, scheduled_time: formatTime(newStartMin), duration: newDur } : t));
       }
     };
-
     const onUp = async () => {
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
-
       if (dragging.type === 'window-start' || dragging.type === 'window-end') {
         onWindowChange(date, localWindow);
       } else if (dragging.type === 'task-move' || dragging.type === 'task-resize-bottom' || dragging.type === 'task-resize-top') {
@@ -214,7 +289,6 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
       }
       setDragging(null);
     };
-
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
     return () => {
@@ -223,45 +297,52 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
     };
   }, [dragging, localWindow, localTasks, date, windowStart, windowEnd, onWindowChange, onUpdateTask]);
 
-  // ── Blocked time creation ─────────────────────────────────────────────────
+  // ── Grid drag (task or block creation) ───────────────────────────────────
   useEffect(() => {
     if (!blockDrag) return;
-
     const onMove = (e) => {
       if (!wrapperRef.current) return;
       const y = getRelativeY(e, wrapperRef.current);
       const mins = snapMinutes(Math.max(0, Math.min(1439, yToMinutes(y))));
-      setBlockDrag(prev => ({ ...prev, endMin: mins }));
+      setBlockDrag(prev => ({ ...prev, endMin: mins, screenX: e.clientX, screenY: e.clientY }));
     };
-
-    const onUp = () => {
+    const onUp = (e) => {
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
-      if (blockDrag && blockDrag.endMin !== blockDrag.startMin) {
+      if (blockDrag) {
         const start = Math.min(blockDrag.startMin, blockDrag.endMin);
         const end = Math.max(blockDrag.startMin, blockDrag.endMin);
         if (end - start >= SNAP) {
-          const next = [...blockedTimes, { date, start: formatTime(start), end: formatTime(end) }];
-          onBlockedTimesChange(next);
+          // Show popup to choose: add task or block time
+          setPendingSlot({
+            startMin: start,
+            endMin: end,
+            screenX: e.clientX,
+            screenY: e.clientY,
+          });
         }
       }
       setBlockDrag(null);
     };
-
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
     return () => {
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
     };
-  }, [blockDrag, blockedTimes, date, onBlockedTimesChange]);
+  }, [blockDrag]);
 
   const handleGridMouseDown = (e) => {
     if (e.target !== gridRef.current) return;
     if (!wrapperRef.current) return;
     const y = getRelativeY(e, wrapperRef.current);
     const mins = snapMinutes(Math.max(0, Math.min(1439, yToMinutes(y))));
-    setBlockDrag({ startMin: mins, endMin: mins });
+    setBlockDrag({ startMin: mins, endMin: mins, screenX: e.clientX, screenY: e.clientY });
+  };
+
+  const handleConfirmBlock = (startMin, endMin) => {
+    const next = [...blockedTimes, { date, start: formatTime(startMin), end: formatTime(endMin) }];
+    onBlockedTimesChange(next);
   };
 
   const removeBlocked = (idx) => {
@@ -318,7 +399,7 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
             </div>
           ))}
 
-          {/* Active block drag preview */}
+          {/* Active drag preview */}
           {blockDrag && blockDrag.endMin !== blockDrag.startMin && (
             <div
               className="timebox-blocked timebox-blocked--preview"
@@ -356,7 +437,6 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
                 className={`timebox-task priority-${task.priority || 'none'} ${isMit ? 'mit' : ''}`}
                 style={{ top: taskTop, height: taskHeight }}
                 onMouseDown={(e) => {
-                  // Don't initiate drag from resize handles
                   if (e.target.classList.contains('timebox-task-resize-top') ||
                     e.target.classList.contains('timebox-task-resize-bottom')) return;
                   startMouseDrag('task-move', {
@@ -399,6 +479,17 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
         </div>
       </div>
 
+      {/* Slot popup (fixed position, rendered outside scroll container) */}
+      {pendingSlot && (
+        <SlotPopup
+          slot={pendingSlot}
+          date={date}
+          onAddTask={onAddTask}
+          onBlockTime={handleConfirmBlock}
+          onCancel={() => setPendingSlot(null)}
+        />
+      )}
+
       {/* Unscheduled tasks panel */}
       {unscheduled.length > 0 && (
         <div className="timebox-unscheduled">
@@ -429,7 +520,7 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
 }
 
 // ── TimeboxView (main) ────────────────────────────────────────────────────────
-function TimeboxView({ tasks, onUpdate }) {
+function TimeboxView({ tasks, onUpdate, onAddTask }) {
   const [subView, setSubView] = useState('day');
   const [mitIds, setMitIds] = useState(() => new Set(loadMit()));
   const [dayWindows, setDayWindows] = useState(loadDayWindows);
@@ -466,10 +557,6 @@ function TimeboxView({ tasks, onUpdate }) {
     });
   };
 
-  const handleUpdateTask = async (taskId, data) => {
-    await onUpdate(taskId, data);
-  };
-
   const handleShuffle = () => setShuffleSeed(s => s + 1);
 
   const sharedProps = {
@@ -478,14 +565,14 @@ function TimeboxView({ tasks, onUpdate }) {
     onBlockedTimesChange: handleBlockedTimesChange,
     mitIds,
     onToggleMit: handleToggleMit,
-    onUpdateTask: handleUpdateTask,
+    onUpdateTask: onUpdate,
+    onAddTask,
     shuffleSeed,
     onShuffle: handleShuffle,
   };
 
   return (
     <div className="timebox-container">
-      {/* Sub-view toggle */}
       <div className="timebox-subview-toggle">
         <button className={`timebox-sub-btn ${subView === 'day' ? 'active' : ''}`} onClick={() => setSubView('day')}>Day</button>
         <button className={`timebox-sub-btn ${subView === 'week' ? 'active' : ''}`} onClick={() => setSubView('week')}>Week</button>

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -1,0 +1,522 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import './TimeboxView.css';
+
+// ── Constants ───────────────────────────────────────────────────────────────
+const PX_PER_HOUR = 64;
+const PX_PER_MIN = PX_PER_HOUR / 60;
+const GRID_HEIGHT = 24 * PX_PER_HOUR; // 1536px
+const SNAP = 15; // minutes
+
+const PRIORITY_ORDER = { urgent: 0, today: 1, tomorrow: 2, later: 3, '': 4 };
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+function parseMinutes(hhmm) {
+  if (!hhmm) return 0;
+  const [h, m] = hhmm.split(':').map(Number);
+  return h * 60 + m;
+}
+
+function formatTime(totalMinutes) {
+  const clamped = Math.max(0, Math.min(1439, totalMinutes));
+  const h = Math.floor(clamped / 60);
+  const m = clamped % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function timeToY(hhmm) {
+  return parseMinutes(hhmm) * PX_PER_MIN;
+}
+
+function yToMinutes(y, snap = SNAP) {
+  return Math.round(y / PX_PER_MIN / snap) * snap;
+}
+
+function snapMinutes(mins, snap = SNAP) {
+  return Math.round(mins / snap) * snap;
+}
+
+function getRelativeY(e, el) {
+  const rect = el.getBoundingClientRect();
+  return e.clientY - rect.top + el.scrollTop;
+}
+
+function advancePastBlocked(cursorMin, durationMin, blockedTimes, date) {
+  let cursor = cursorMin;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const b of blockedTimes) {
+      if (b.date !== date) continue;
+      const bs = parseMinutes(b.start);
+      const be = parseMinutes(b.end);
+      if (cursor < be && cursor + durationMin > bs) {
+        cursor = be;
+        changed = true;
+      }
+    }
+  }
+  return cursor;
+}
+
+function seededRandom(seed) {
+  const x = Math.sin(seed + 1) * 10000;
+  return x - Math.floor(x);
+}
+
+function formatDateLabel(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00');
+  const today = new Date(); today.setHours(0, 0, 0, 0);
+  const diff = Math.floor((d - today) / 86400000);
+  const dayName = d.toLocaleDateString('en-US', { weekday: 'short' });
+  const label = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  if (diff === 0) return `Today — ${label}`;
+  if (diff === 1) return `Tomorrow — ${label}`;
+  return `${dayName} — ${label}`;
+}
+
+function getWeekDates() {
+  const today = new Date(); today.setHours(0, 0, 0, 0);
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(today);
+    d.setDate(today.getDate() + i);
+    return d.toISOString().split('T')[0];
+  });
+}
+
+// ── localStorage helpers ──────────────────────────────────────────────────────
+function loadDayWindows() {
+  try { return JSON.parse(localStorage.getItem('ztd_day_windows') || '{}'); }
+  catch { return {}; }
+}
+function saveDayWindows(v) { localStorage.setItem('ztd_day_windows', JSON.stringify(v)); }
+
+function loadBlockedTimes() {
+  try { return JSON.parse(localStorage.getItem('ztd_blocked_times') || '[]'); }
+  catch { return []; }
+}
+function saveBlockedTimes(v) { localStorage.setItem('ztd_blocked_times', JSON.stringify(v)); }
+
+function loadMit() {
+  try { return JSON.parse(localStorage.getItem('ztd_mit_tasks') || '[]'); }
+  catch { return []; }
+}
+function saveMit(ids) { localStorage.setItem('ztd_mit_tasks', JSON.stringify([...ids])); }
+
+// ── TimeboxDayColumn ─────────────────────────────────────────────────────────
+function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes, onBlockedTimesChange, mitIds, onToggleMit, onUpdateTask, isWeekView, shuffleSeed, onShuffle }) {
+  const gridRef = useRef(null);
+  const wrapperRef = useRef(null);
+  const [dragging, setDragging] = useState(null); // { type, taskId, startY, startVal }
+  const [localTasks, setLocalTasks] = useState(tasks);
+  const [localWindow, setLocalWindow] = useState(dayWindow);
+  const [blockDrag, setBlockDrag] = useState(null); // { startMin, endMin }
+  const [unscheduledOpen, setUnscheduledOpen] = useState(true);
+
+  useEffect(() => { setLocalTasks(tasks); }, [tasks]);
+  useEffect(() => { setLocalWindow(dayWindow); }, [dayWindow]);
+
+  const columnTasks = localTasks.filter(t =>
+    t.scheduled_date === date || (!t.scheduled_date && t.due === date)
+  );
+  const scheduled = columnTasks.filter(t => t.scheduled_time);
+  const unscheduled = columnTasks.filter(t => !t.scheduled_time);
+
+  const windowStart = parseMinutes(localWindow.start);
+  const windowEnd = parseMinutes(localWindow.end);
+
+  // Auto-scroll to window start on mount
+  useEffect(() => {
+    if (wrapperRef.current) {
+      wrapperRef.current.scrollTop = Math.max(0, timeToY(localWindow.start) - 40);
+    }
+  }, []); // eslint-disable-line
+
+  // ── Auto-schedule ──────────────────────────────────────────────────────────
+  const handleAutoSchedule = useCallback(async () => {
+    onShuffle(); // increment seed
+    const PRIO = PRIORITY_ORDER;
+    let ordered = [...columnTasks].sort((a, b) => (PRIO[a.priority] ?? 4) - (PRIO[b.priority] ?? 4));
+
+    // shuffle using current seed + 1 (seed was just incremented)
+    const seed = shuffleSeed + 1;
+    for (let i = ordered.length - 1; i > 0; i--) {
+      const j = Math.floor(seededRandom(seed + i) * (i + 1));
+      [ordered[i], ordered[j]] = [ordered[j], ordered[i]];
+    }
+
+    let cursor = windowStart;
+    const updates = [];
+    for (const task of ordered) {
+      const dur = task.duration || 30;
+      cursor = advancePastBlocked(cursor, dur, blockedTimes, date);
+      if (cursor + dur > windowEnd) break;
+      updates.push({ id: task.id, scheduled_time: formatTime(cursor), scheduled_date: date });
+      cursor += dur;
+    }
+
+    // optimistic update
+    const updatedMap = {};
+    updates.forEach(u => { updatedMap[u.id] = u; });
+    setLocalTasks(prev => prev.map(t => updatedMap[t.id] ? { ...t, ...updatedMap[t.id] } : t));
+
+    await Promise.all(updates.map(u => onUpdateTask(u.id, { scheduled_time: u.scheduled_time, scheduled_date: u.scheduled_date })));
+  }, [columnTasks, blockedTimes, date, windowStart, windowEnd, shuffleSeed, onShuffle, onUpdateTask]);
+
+  // ── Mouse drag helpers ─────────────────────────────────────────────────────
+  const startMouseDrag = useCallback((type, extra, e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragging({ type, startY: e.clientY, ...extra });
+  }, []);
+
+  useEffect(() => {
+    if (!dragging) return;
+
+    const onMove = (e) => {
+      const deltaY = e.clientY - dragging.startY;
+      const deltaMins = yToMinutes(deltaY);
+
+      if (dragging.type === 'window-start') {
+        const newMin = Math.max(0, Math.min(windowEnd - 60, snapMinutes(dragging.origMin + deltaMins)));
+        setLocalWindow(w => ({ ...w, start: formatTime(newMin) }));
+      } else if (dragging.type === 'window-end') {
+        const newMin = Math.max(windowStart + 60, Math.min(1439, snapMinutes(dragging.origMin + deltaMins)));
+        setLocalWindow(w => ({ ...w, end: formatTime(newMin) }));
+      } else if (dragging.type === 'task-move') {
+        const newMin = Math.max(windowStart, Math.min(windowEnd - (dragging.duration || 30), snapMinutes(dragging.origMin + deltaMins)));
+        setLocalTasks(prev => prev.map(t => t.id === dragging.taskId ? { ...t, scheduled_time: formatTime(newMin) } : t));
+      } else if (dragging.type === 'task-resize-bottom') {
+        const newEndMin = Math.max(dragging.origMin + SNAP, Math.min(windowEnd, snapMinutes(dragging.origEndMin + deltaMins)));
+        const newDur = newEndMin - dragging.origMin;
+        setLocalTasks(prev => prev.map(t => t.id === dragging.taskId ? { ...t, duration: newDur } : t));
+      } else if (dragging.type === 'task-resize-top') {
+        const newStartMin = Math.max(windowStart, Math.min(dragging.origEndMin - SNAP, snapMinutes(dragging.origMin + deltaMins)));
+        const newDur = dragging.origEndMin - newStartMin;
+        setLocalTasks(prev => prev.map(t => t.id === dragging.taskId ? { ...t, scheduled_time: formatTime(newStartMin), duration: newDur } : t));
+      }
+    };
+
+    const onUp = async () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+
+      if (dragging.type === 'window-start' || dragging.type === 'window-end') {
+        onWindowChange(date, localWindow);
+      } else if (dragging.type === 'task-move' || dragging.type === 'task-resize-bottom' || dragging.type === 'task-resize-top') {
+        const updated = localTasks.find(t => t.id === dragging.taskId);
+        if (updated) {
+          await onUpdateTask(updated.id, {
+            scheduled_time: updated.scheduled_time,
+            scheduled_date: updated.scheduled_date || date,
+            duration: updated.duration,
+          });
+        }
+      }
+      setDragging(null);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    return () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+  }, [dragging, localWindow, localTasks, date, windowStart, windowEnd, onWindowChange, onUpdateTask]);
+
+  // ── Blocked time creation ─────────────────────────────────────────────────
+  useEffect(() => {
+    if (!blockDrag) return;
+
+    const onMove = (e) => {
+      if (!wrapperRef.current) return;
+      const y = getRelativeY(e, wrapperRef.current);
+      const mins = snapMinutes(Math.max(0, Math.min(1439, yToMinutes(y))));
+      setBlockDrag(prev => ({ ...prev, endMin: mins }));
+    };
+
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      if (blockDrag && blockDrag.endMin !== blockDrag.startMin) {
+        const start = Math.min(blockDrag.startMin, blockDrag.endMin);
+        const end = Math.max(blockDrag.startMin, blockDrag.endMin);
+        if (end - start >= SNAP) {
+          const next = [...blockedTimes, { date, start: formatTime(start), end: formatTime(end) }];
+          onBlockedTimesChange(next);
+        }
+      }
+      setBlockDrag(null);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    return () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+  }, [blockDrag, blockedTimes, date, onBlockedTimesChange]);
+
+  const handleGridMouseDown = (e) => {
+    if (e.target !== gridRef.current) return;
+    if (!wrapperRef.current) return;
+    const y = getRelativeY(e, wrapperRef.current);
+    const mins = snapMinutes(Math.max(0, Math.min(1439, yToMinutes(y))));
+    setBlockDrag({ startMin: mins, endMin: mins });
+  };
+
+  const removeBlocked = (idx) => {
+    const next = blockedTimes.filter((_, i) => i !== idx);
+    onBlockedTimesChange(next);
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  const hourLabels = Array.from({ length: 24 }, (_, h) => h);
+  const dateBlockedForDay = blockedTimes.filter(b => b.date === date);
+  const isToday = date === new Date().toISOString().split('T')[0];
+
+  return (
+    <div className={`timebox-day-column ${isWeekView ? 'week-col' : ''}`}>
+      {/* Column header */}
+      <div className={`timebox-col-header ${isToday ? 'today' : ''}`}>
+        <div className="timebox-col-date">{formatDateLabel(date)}</div>
+        <div className="timebox-col-actions">
+          <span className="timebox-mit-count">⭐ {[...mitIds].filter(id => columnTasks.some(t => t.id === id)).length}/3</span>
+          <button className="timebox-auto-btn" onClick={handleAutoSchedule} title="Auto-schedule tasks">
+            ⚡ Auto
+          </button>
+        </div>
+      </div>
+
+      {/* Grid */}
+      <div className="timebox-grid-wrapper" ref={wrapperRef}>
+        <div className="timebox-grid" ref={gridRef} onMouseDown={handleGridMouseDown}
+          style={{ height: GRID_HEIGHT }}>
+
+          {/* Hour lines + labels */}
+          {hourLabels.map(h => (
+            <React.Fragment key={h}>
+              <div className="timebox-hour-label" style={{ top: h * PX_PER_HOUR }}>{String(h).padStart(2, '0')}</div>
+              <div className="timebox-hour-line" style={{ top: h * PX_PER_HOUR }} />
+              <div className="timebox-halfhour-line" style={{ top: h * PX_PER_HOUR + PX_PER_HOUR / 2 }} />
+            </React.Fragment>
+          ))}
+
+          {/* Inactive overlays */}
+          <div className="timebox-inactive" style={{ top: 0, height: timeToY(localWindow.start) }} />
+          <div className="timebox-inactive" style={{ top: timeToY(localWindow.end), height: GRID_HEIGHT - timeToY(localWindow.end) }} />
+
+          {/* Blocked times */}
+          {dateBlockedForDay.map((b, i) => (
+            <div
+              key={i}
+              className="timebox-blocked"
+              style={{ top: timeToY(b.start), height: Math.max(8, timeToY(b.end) - timeToY(b.start)) }}
+              onClick={() => removeBlocked(blockedTimes.indexOf(b))}
+              title="Click to remove blocked time"
+            >
+              <span className="timebox-blocked-label">Blocked · {b.start}–{b.end}</span>
+            </div>
+          ))}
+
+          {/* Active block drag preview */}
+          {blockDrag && blockDrag.endMin !== blockDrag.startMin && (
+            <div
+              className="timebox-blocked timebox-blocked--preview"
+              style={{
+                top: Math.min(blockDrag.startMin, blockDrag.endMin) * PX_PER_MIN,
+                height: Math.abs(blockDrag.endMin - blockDrag.startMin) * PX_PER_MIN,
+              }}
+            />
+          )}
+
+          {/* Window bars */}
+          <div
+            className="window-bar window-bar--start"
+            style={{ top: timeToY(localWindow.start) }}
+            onMouseDown={(e) => startMouseDrag('window-start', { origMin: parseMinutes(localWindow.start) }, e)}
+          >
+            <span className="window-bar-label">▲ {localWindow.start}</span>
+          </div>
+          <div
+            className="window-bar window-bar--end"
+            style={{ top: timeToY(localWindow.end) }}
+            onMouseDown={(e) => startMouseDrag('window-end', { origMin: parseMinutes(localWindow.end) }, e)}
+          >
+            <span className="window-bar-label">▼ {localWindow.end}</span>
+          </div>
+
+          {/* Scheduled task blocks */}
+          {scheduled.map(task => {
+            const isMit = mitIds.has(task.id);
+            const taskTop = timeToY(task.scheduled_time);
+            const taskHeight = Math.max(22, (task.duration || 30) * PX_PER_MIN);
+            return (
+              <div
+                key={task.id}
+                className={`timebox-task priority-${task.priority || 'none'} ${isMit ? 'mit' : ''}`}
+                style={{ top: taskTop, height: taskHeight }}
+                onMouseDown={(e) => {
+                  // Don't initiate drag from resize handles
+                  if (e.target.classList.contains('timebox-task-resize-top') ||
+                    e.target.classList.contains('timebox-task-resize-bottom')) return;
+                  startMouseDrag('task-move', {
+                    taskId: task.id,
+                    origMin: parseMinutes(task.scheduled_time),
+                    duration: task.duration || 30,
+                  }, e);
+                }}
+              >
+                <div
+                  className="timebox-task-resize-top"
+                  onMouseDown={(e) => startMouseDrag('task-resize-top', {
+                    taskId: task.id,
+                    origMin: parseMinutes(task.scheduled_time),
+                    origEndMin: parseMinutes(task.scheduled_time) + (task.duration || 30),
+                  }, e)}
+                />
+                <div className="timebox-task-body">
+                  <span className="timebox-task-desc">{task.description}</span>
+                  <div className="timebox-task-meta">
+                    <span className="timebox-task-duration">{task.duration || 30}m</span>
+                    <button
+                      className={`timebox-mit-btn ${isMit ? 'active' : ''} ${!isMit && mitIds.size >= 3 ? 'disabled' : ''}`}
+                      onClick={(e) => { e.stopPropagation(); onToggleMit(task.id); }}
+                      title={isMit ? 'Remove from MIT' : 'Mark as Most Important Task'}
+                    >⭐</button>
+                  </div>
+                </div>
+                <div
+                  className="timebox-task-resize-bottom"
+                  onMouseDown={(e) => startMouseDrag('task-resize-bottom', {
+                    taskId: task.id,
+                    origMin: parseMinutes(task.scheduled_time),
+                    origEndMin: parseMinutes(task.scheduled_time) + (task.duration || 30),
+                  }, e)}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Unscheduled tasks panel */}
+      {unscheduled.length > 0 && (
+        <div className="timebox-unscheduled">
+          <button className="timebox-unscheduled-toggle" onClick={() => setUnscheduledOpen(o => !o)}>
+            <span>{unscheduledOpen ? '▾' : '▸'}</span>
+            Unscheduled
+            <span className="timebox-unscheduled-count">{unscheduled.length}</span>
+          </button>
+          {unscheduledOpen && (
+            <div className="timebox-unscheduled-list">
+              {unscheduled.map(task => (
+                <div key={task.id} className={`timebox-unscheduled-chip priority-${task.priority || 'none'} ${mitIds.has(task.id) ? 'mit' : ''}`}>
+                  <span className="timebox-chip-desc">{task.description}</span>
+                  <span className="timebox-chip-dur">{task.duration || 30}m</span>
+                  <button
+                    className={`timebox-mit-btn ${mitIds.has(task.id) ? 'active' : ''} ${!mitIds.has(task.id) && mitIds.size >= 3 ? 'disabled' : ''}`}
+                    onClick={() => onToggleMit(task.id)}
+                    title="Toggle Most Important Task"
+                  >⭐</button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── TimeboxView (main) ────────────────────────────────────────────────────────
+function TimeboxView({ tasks, onUpdate }) {
+  const [subView, setSubView] = useState('day');
+  const [mitIds, setMitIds] = useState(() => new Set(loadMit()));
+  const [dayWindows, setDayWindows] = useState(loadDayWindows);
+  const [blockedTimes, setBlockedTimes] = useState(loadBlockedTimes);
+  const [shuffleSeed, setShuffleSeed] = useState(0);
+
+  const today = new Date().toISOString().split('T')[0];
+  const weekDates = getWeekDates();
+
+  const getWindowForDate = (date) =>
+    dayWindows[date] || { start: '09:00', end: '18:00' };
+
+  const handleWindowChange = (date, newWindow) => {
+    const next = { ...dayWindows, [date]: newWindow };
+    setDayWindows(next);
+    saveDayWindows(next);
+  };
+
+  const handleBlockedTimesChange = (next) => {
+    setBlockedTimes(next);
+    saveBlockedTimes(next);
+  };
+
+  const handleToggleMit = (taskId) => {
+    setMitIds(prev => {
+      const next = new Set(prev);
+      if (next.has(taskId)) {
+        next.delete(taskId);
+      } else if (next.size < 3) {
+        next.add(taskId);
+      }
+      saveMit(next);
+      return next;
+    });
+  };
+
+  const handleUpdateTask = async (taskId, data) => {
+    await onUpdate(taskId, data);
+  };
+
+  const handleShuffle = () => setShuffleSeed(s => s + 1);
+
+  const sharedProps = {
+    tasks,
+    blockedTimes,
+    onBlockedTimesChange: handleBlockedTimesChange,
+    mitIds,
+    onToggleMit: handleToggleMit,
+    onUpdateTask: handleUpdateTask,
+    shuffleSeed,
+    onShuffle: handleShuffle,
+  };
+
+  return (
+    <div className="timebox-container">
+      {/* Sub-view toggle */}
+      <div className="timebox-subview-toggle">
+        <button className={`timebox-sub-btn ${subView === 'day' ? 'active' : ''}`} onClick={() => setSubView('day')}>Day</button>
+        <button className={`timebox-sub-btn ${subView === 'week' ? 'active' : ''}`} onClick={() => setSubView('week')}>Week</button>
+      </div>
+
+      {subView === 'day' && (
+        <TimeboxDayColumn
+          {...sharedProps}
+          date={today}
+          dayWindow={getWindowForDate(today)}
+          onWindowChange={handleWindowChange}
+          isWeekView={false}
+        />
+      )}
+
+      {subView === 'week' && (
+        <div className="timebox-week-wrapper">
+          {weekDates.map(date => (
+            <TimeboxDayColumn
+              key={date}
+              {...sharedProps}
+              date={date}
+              dayWindow={getWindowForDate(date)}
+              onWindowChange={handleWindowChange}
+              isWeekView
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TimeboxView;


### PR DESCRIPTION
- New Timebox tab with Day and Week sub-views
- Google Calendar-style time grid (64px/hr, scrollable)
- Tasks for today appear as draggable blocks at their scheduled time
- Drag task body to move, drag top/bottom handle to resize duration
- Draggable start/end day window bars per date (saved to localStorage)
- Auto-schedule button places tasks sequentially; each press shuffles order
- MIT (Most Important Task) toggle — up to 3 tasks highlighted gold
- Click-drag on empty grid to block time slots; click to remove
- Week view shows 7 days side by side, each with independent window
- Backend: added duration, scheduled_time, scheduled_date fields to Task
- DB migration runs on startup (ALTER TABLE, safe for existing data)

https://claude.ai/code/session_01EBZq2ddn3oVzJfTRNTusGi