### PR TITLE
Fix timebox bugs and add task editing features

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -234,6 +234,11 @@ def register():
         password_hash=generate_password_hash(data['password']),
     )
     db.session.add(user)
+    db.session.flush()  # get user.id before commit
+
+    # Create default "Main Hat" for new users
+    main_hat = Hat(user_id=user.id, name='Main Hat', emoji='🎩', color='#667eea', position=0)
+    db.session.add(main_hat)
     db.session.commit()
 
     token = create_access_token(identity=str(user.id))
@@ -384,6 +389,11 @@ def add_task():
             hat = Hat.query.filter_by(id=hat_id, user_id=user_id).first()
             if not hat:
                 hat_id = None
+        # Default to Main Hat if no hat specified
+        if hat_id is None:
+            main_hat = Hat.query.filter_by(user_id=user_id, name='Main Hat').first()
+            if main_hat:
+                hat_id = main_hat.id
 
         max_pos_q = Task.query.filter_by(user_id=user_id)
         if hat_id:

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -497,6 +497,7 @@ function TaskApp() {
         {viewMode === 'timebox' && (
           <TimeboxView
             tasks={getVisibleTasks()}
+            hats={hats}
             onUpdate={updateTask}
             onAddTask={addTask}
             maxHistoryDays={subscription?.tier === 'premium' ? 90 : 14}

--- a/frontend/src/components/TaskItem.js
+++ b/frontend/src/components/TaskItem.js
@@ -197,7 +197,7 @@ const TaskItem = ({
             <label className="edit-label">Subtasks</label>
             <div className="edit-subtasks">
               {editData.subtasks.map((st, i) => (
-                <div key={st.id} className="edit-subtask-row">
+                <div key={st.id ?? i} className="edit-subtask-row">
                   <span className="edit-subtask-bullet">·</span>
                   <input
                     className="edit-subtask-input"
@@ -299,8 +299,8 @@ const TaskItem = ({
                   <div className="subtask-progress-fill" style={{ width: `${progress}%` }} />
                 </div>
               )}
-              {localSubtasks.map((st) => (
-                <label key={st.id} className={`subtask-item ${st.done ? 'done' : ''}`}>
+              {localSubtasks.map((st, i) => (
+                <label key={st.id ?? i} className={`subtask-item ${st.done ? 'done' : ''}`}>
                   <input
                     type="checkbox"
                     checked={st.done}

--- a/frontend/src/components/TimeboxView.css
+++ b/frontend/src/components/TimeboxView.css
@@ -665,3 +665,216 @@
 .slot-popup-btn--cancel:hover {
   color: rgba(255, 255, 255, 0.6);
 }
+
+/* ── Task Edit Modal (tef-*) ─────────────────────────────────────────────── */
+.tef-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(3px);
+  z-index: 1100;
+}
+
+.tef-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1101;
+  width: min(440px, 92vw);
+  background: #1a1730;
+  border: 1px solid rgba(102, 126, 234, 0.35);
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.tef-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.tef-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  letter-spacing: 0.3px;
+}
+
+.tef-close {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.35);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.tef-close:hover {
+  color: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.tef-body {
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+  overflow-y: auto;
+  max-height: 60vh;
+}
+
+.tef-row {
+  display: flex;
+  gap: 12px;
+}
+
+.tef-row .tef-field {
+  flex: 1;
+}
+
+.tef-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.tef-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.4);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.tef-input,
+.tef-select {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 13px;
+  font-family: inherit;
+  padding: 7px 10px;
+  outline: none;
+  transition: border-color 0.15s;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.tef-input:focus,
+.tef-select:focus {
+  border-color: rgba(102, 126, 234, 0.6);
+}
+
+.tef-select option {
+  background: #1a1730;
+}
+
+.tef-subtasks {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 16px;
+  padding: 4px 0;
+}
+
+.tef-subtask-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tef-subtask-input {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 7px;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 12px;
+  font-family: inherit;
+  padding: 5px 8px;
+  outline: none;
+}
+
+.tef-subtask-input:focus {
+  border-color: rgba(102, 126, 234, 0.5);
+}
+
+.tef-subtask-remove {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 3px 5px;
+  border-radius: 5px;
+  transition: color 0.15s;
+}
+
+.tef-subtask-remove:hover {
+  color: #f87171;
+}
+
+.tef-subtask-add {
+  background: none;
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  border-radius: 7px;
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 5px 8px;
+  text-align: left;
+  transition: all 0.15s;
+}
+
+.tef-subtask-add:hover {
+  border-color: rgba(102, 126, 234, 0.45);
+  color: rgba(165, 180, 252, 0.8);
+}
+
+.tef-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 18px 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.tef-btn {
+  padding: 7px 18px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  transition: all 0.15s;
+}
+
+.tef-btn--cancel {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.tef-btn--cancel:hover {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.tef-btn--save {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+}
+
+.tef-btn--save:hover {
+  filter: brightness(1.1);
+}

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -74,12 +74,19 @@ function formatDateLabel(dateStr) {
   return `${dayName} — ${label}`;
 }
 
+function toLocalDateStr(d) {
+  const y = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${mo}-${day}`;
+}
+
 function getWeekDates(startOffset = 0) {
   const today = new Date(); today.setHours(0, 0, 0, 0);
   return Array.from({ length: 7 }, (_, i) => {
     const d = new Date(today);
     d.setDate(today.getDate() + startOffset + i);
-    return d.toISOString().split('T')[0];
+    return toLocalDateStr(d);
   });
 }
 
@@ -201,8 +208,136 @@ function SlotPopup({ slot, date, onAddTask, onBlockTime, onCancel }) {
   );
 }
 
+// ── TaskEditModal ─────────────────────────────────────────────────────────────
+let _stIdCounter = Date.now();
+const newStId = () => `st-${++_stIdCounter}`;
+
+function TaskEditModal({ task, hats, onSave, onClose }) {
+  const [editData, setEditData] = useState({
+    description: task.description,
+    category: task.category || '',
+    priority: task.priority || '',
+    hat_id: task.hat_id ?? '',
+    subtasks: task.subtasks ? task.subtasks.map(s => ({ ...s })) : [],
+  });
+
+  const handleSave = () => {
+    onSave(task.id, {
+      description: editData.description.trim() || task.description,
+      category: editData.category.trim(),
+      priority: editData.priority,
+      hat_id: editData.hat_id !== '' ? Number(editData.hat_id) : null,
+      subtasks: editData.subtasks,
+    });
+  };
+
+  const addSubtask = () =>
+    setEditData(d => ({ ...d, subtasks: [...d.subtasks, { id: newStId(), text: '', done: false }] }));
+
+  const updateSubtask = (stId, text) =>
+    setEditData(d => ({ ...d, subtasks: d.subtasks.map(s => s.id === stId ? { ...s, text } : s) }));
+
+  const removeSubtask = (stId) =>
+    setEditData(d => ({ ...d, subtasks: d.subtasks.filter(s => s.id !== stId) }));
+
+  return (
+    <>
+      <div className="tef-backdrop" onClick={onClose} />
+      <div className="tef-modal">
+        <div className="tef-header">
+          <span className="tef-title">Edit Task</span>
+          <button className="tef-close" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="tef-body">
+          <div className="tef-field">
+            <label className="tef-label">Description</label>
+            <input
+              className="tef-input"
+              value={editData.description}
+              onChange={e => setEditData(d => ({ ...d, description: e.target.value }))}
+              onKeyDown={e => { if (e.key === 'Enter') handleSave(); if (e.key === 'Escape') onClose(); }}
+              autoFocus
+            />
+          </div>
+
+          <div className="tef-row">
+            <div className="tef-field">
+              <label className="tef-label">Category</label>
+              <input
+                className="tef-input"
+                value={editData.category}
+                onChange={e => setEditData(d => ({ ...d, category: e.target.value }))}
+                placeholder="e.g. work"
+              />
+            </div>
+            <div className="tef-field">
+              <label className="tef-label">Priority</label>
+              <select
+                className="tef-select"
+                value={editData.priority}
+                onChange={e => setEditData(d => ({ ...d, priority: e.target.value }))}
+              >
+                <option value="">None</option>
+                <option value="urgent">Urgent</option>
+                <option value="today">Today</option>
+                <option value="tomorrow">Tomorrow</option>
+                <option value="later">Later</option>
+              </select>
+            </div>
+          </div>
+
+          {hats && hats.length > 0 && (
+            <div className="tef-field">
+              <label className="tef-label">Hat</label>
+              <select
+                className="tef-select"
+                value={editData.hat_id}
+                onChange={e => setEditData(d => ({ ...d, hat_id: e.target.value }))}
+              >
+                <option value="">No Hat</option>
+                {hats.map(h => (
+                  <option key={h.id} value={h.id}>{h.emoji} {h.name}</option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className="tef-field">
+            <label className="tef-label">Subtasks</label>
+            <div className="tef-subtasks" onDoubleClick={e => { if (e.target === e.currentTarget) addSubtask(); }}>
+              {editData.subtasks.map((st, i) => (
+                <div key={st.id ?? i} className="tef-subtask-row" onDoubleClick={e => { if (e.target === e.currentTarget) addSubtask(); }}>
+                  <input
+                    className="tef-subtask-input"
+                    value={st.text}
+                    placeholder="Subtask…"
+                    onChange={e => updateSubtask(st.id, e.target.value)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') { e.preventDefault(); addSubtask(); }
+                      if (e.key === 'Backspace' && st.text === '') removeSubtask(st.id);
+                    }}
+                    autoFocus={i === editData.subtasks.length - 1 && st.text === ''}
+                  />
+                  <button className="tef-subtask-remove" onClick={() => removeSubtask(st.id)}>✕</button>
+                </div>
+              ))}
+              <button className="tef-subtask-add" onClick={addSubtask}>+ Add subtask</button>
+            </div>
+          </div>
+        </div>
+
+        <div className="tef-footer">
+          <button className="tef-btn tef-btn--cancel" onClick={onClose}>Cancel</button>
+          <button className="tef-btn tef-btn--save" onClick={handleSave}>Save</button>
+        </div>
+      </div>
+    </>
+  );
+}
+
 // ── TimeboxDayColumn ─────────────────────────────────────────────────────────
-function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes, onBlockedTimesChange, mitIds, onToggleMit, onUpdateTask, onAddTask, isWeekView, shuffleSeed, onShuffle }) {
+function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blockedTimes, onBlockedTimesChange, mitIds, onToggleMit, onUpdateTask, onAddTask, isWeekView, shuffleSeed, onShuffle }) {
   const gridRef = useRef(null);
   const wrapperRef = useRef(null);
   const [dragging, setDragging] = useState(null);
@@ -211,9 +346,16 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
   const [blockDrag, setBlockDrag] = useState(null); // { startMin, endMin, screenX, screenY }
   const [pendingSlot, setPendingSlot] = useState(null); // shown after drag ends
   const [unscheduledOpen, setUnscheduledOpen] = useState(true);
+  const [editingTask, setEditingTask] = useState(null);
+
+  // Refs so drag handlers always read the latest state without re-registering listeners
+  const localTasksRef = useRef(localTasks);
+  const localWindowRef = useRef(localWindow);
 
   useEffect(() => { setLocalTasks(tasks); }, [tasks]);
   useEffect(() => { setLocalWindow(dayWindow); }, [dayWindow]);
+  useEffect(() => { localTasksRef.current = localTasks; }, [localTasks]);
+  useEffect(() => { localWindowRef.current = localWindow; }, [localWindow]);
 
   const columnTasks = localTasks.filter(t =>
     t.scheduled_date === date || (!t.scheduled_date && t.due === date)
@@ -268,21 +410,23 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
     const onMove = (e) => {
       const deltaY = e.clientY - dragging.startY;
       const deltaMins = yToMinutes(deltaY);
+      const wStart = parseMinutes(localWindowRef.current.start);
+      const wEnd = parseMinutes(localWindowRef.current.end);
       if (dragging.type === 'window-start') {
-        const newMin = Math.max(0, Math.min(windowEnd - 60, snapMinutes(dragging.origMin + deltaMins)));
+        const newMin = Math.max(0, Math.min(wEnd - 60, snapMinutes(dragging.origMin + deltaMins)));
         setLocalWindow(w => ({ ...w, start: formatTime(newMin) }));
       } else if (dragging.type === 'window-end') {
-        const newMin = Math.max(windowStart + 60, Math.min(1439, snapMinutes(dragging.origMin + deltaMins)));
+        const newMin = Math.max(wStart + 60, Math.min(1439, snapMinutes(dragging.origMin + deltaMins)));
         setLocalWindow(w => ({ ...w, end: formatTime(newMin) }));
       } else if (dragging.type === 'task-move') {
-        const newMin = Math.max(windowStart, Math.min(windowEnd - (dragging.duration || 30), snapMinutes(dragging.origMin + deltaMins)));
+        const newMin = Math.max(wStart, Math.min(wEnd - (dragging.duration || 30), snapMinutes(dragging.origMin + deltaMins)));
         setLocalTasks(prev => prev.map(t => t.id === dragging.taskId ? { ...t, scheduled_time: formatTime(newMin) } : t));
       } else if (dragging.type === 'task-resize-bottom') {
-        const newEndMin = Math.max(dragging.origMin + SNAP, Math.min(windowEnd, snapMinutes(dragging.origEndMin + deltaMins)));
+        const newEndMin = Math.max(dragging.origMin + SNAP, Math.min(wEnd, snapMinutes(dragging.origEndMin + deltaMins)));
         const newDur = newEndMin - dragging.origMin;
         setLocalTasks(prev => prev.map(t => t.id === dragging.taskId ? { ...t, duration: newDur } : t));
       } else if (dragging.type === 'task-resize-top') {
-        const newStartMin = Math.max(windowStart, Math.min(dragging.origEndMin - SNAP, snapMinutes(dragging.origMin + deltaMins)));
+        const newStartMin = Math.max(wStart, Math.min(dragging.origEndMin - SNAP, snapMinutes(dragging.origMin + deltaMins)));
         const newDur = dragging.origEndMin - newStartMin;
         setLocalTasks(prev => prev.map(t => t.id === dragging.taskId ? { ...t, scheduled_time: formatTime(newStartMin), duration: newDur } : t));
       }
@@ -291,9 +435,9 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
       if (dragging.type === 'window-start' || dragging.type === 'window-end') {
-        onWindowChange(date, localWindow);
+        onWindowChange(date, localWindowRef.current);
       } else if (dragging.type === 'task-move' || dragging.type === 'task-resize-bottom' || dragging.type === 'task-resize-top') {
-        const updated = localTasks.find(t => t.id === dragging.taskId);
+        const updated = localTasksRef.current.find(t => t.id === dragging.taskId);
         if (updated) {
           // Detect cross-day drop by checking which day column is under the cursor
           let targetDate = date;
@@ -317,7 +461,7 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
     };
-  }, [dragging, localWindow, localTasks, date, windowStart, windowEnd, onWindowChange, onUpdateTask]);
+  }, [dragging, date, onWindowChange, onUpdateTask]);
 
   // ── Grid drag (task or block creation) ───────────────────────────────────
   useEffect(() => {
@@ -375,7 +519,7 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
   // ── Render ─────────────────────────────────────────────────────────────────
   const hourLabels = Array.from({ length: 24 }, (_, h) => h);
   const dateBlockedForDay = blockedTimes.filter(b => b.date === date);
-  const isToday = date === new Date().toISOString().split('T')[0];
+  const isToday = date === toLocalDateStr(new Date());
   const nowMinutes = useNowMinutes();
 
   return (
@@ -466,6 +610,7 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
                 key={task.id}
                 className={`timebox-task priority-${task.priority || 'none'} ${isMit ? 'mit' : ''}`}
                 style={{ top: taskTop, height: taskHeight }}
+                onDoubleClick={(e) => { e.stopPropagation(); setEditingTask(task); }}
                 onMouseDown={(e) => {
                   if (e.target.classList.contains('timebox-task-resize-top') ||
                     e.target.classList.contains('timebox-task-resize-bottom')) return;
@@ -520,6 +665,20 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
         />
       )}
 
+      {/* Task edit modal */}
+      {editingTask && (
+        <TaskEditModal
+          task={editingTask}
+          hats={hats}
+          onSave={async (id, data) => {
+            setLocalTasks(prev => prev.map(t => t.id === id ? { ...t, ...data } : t));
+            await onUpdateTask(id, data);
+            setEditingTask(null);
+          }}
+          onClose={() => setEditingTask(null)}
+        />
+      )}
+
       {/* Unscheduled tasks panel */}
       {unscheduled.length > 0 && (
         <div className="timebox-unscheduled">
@@ -550,7 +709,7 @@ function TimeboxDayColumn({ date, tasks, dayWindow, onWindowChange, blockedTimes
 }
 
 // ── TimeboxView (main) ────────────────────────────────────────────────────────
-function TimeboxView({ tasks, onUpdate, onAddTask, maxHistoryDays = 14 }) {
+function TimeboxView({ tasks, hats, onUpdate, onAddTask, maxHistoryDays = 14 }) {
   const [subView, setSubView] = useState('day');
   const [mitIds, setMitIds] = useState(() => new Set(loadMit()));
   const [dayWindows, setDayWindows] = useState(loadDayWindows);
@@ -558,7 +717,7 @@ function TimeboxView({ tasks, onUpdate, onAddTask, maxHistoryDays = 14 }) {
   const [shuffleSeed, setShuffleSeed] = useState(0);
   const [weekStartOffset, setWeekStartOffset] = useState(0); // days from today
 
-  const today = new Date().toISOString().split('T')[0];
+  const today = toLocalDateStr(new Date());
   const weekDates = getWeekDates(weekStartOffset);
 
   const canGoBack = weekStartOffset > -maxHistoryDays;
@@ -605,6 +764,7 @@ function TimeboxView({ tasks, onUpdate, onAddTask, maxHistoryDays = 14 }) {
 
   const sharedProps = {
     tasks,
+    hats,
     blockedTimes,
     onBlockedTimesChange: handleBlockedTimesChange,
     mitIds,


### PR DESCRIPTION
- Fix timezone bug: replace toISOString().split('T')[0] with toLocalDateStr() helper so week view starts on today in UTC+ timezones
- Fix cross-day drag: use localTasksRef/localWindowRef in drag useEffect to avoid stale closure re-registering mouseup listener on every mousemove
- Add double-click to edit tasks in timebox weekly/day view (TaskEditModal) with description, category, priority, hat picker, and subtask editor
- Double-click below a subtask in the edit modal to add a new one
- Pass hats from App.js to TimeboxView so hat selector works in edit modal
- Backend: create default 'Main Hat' on user registration; new tasks default to Main Hat when no hat is explicitly selected
- Fix subtask list rendering for items missing id (use index as key fallback)

https://claude.ai/code/session_01EBZq2ddn3oVzJfTRNTusGi