### PR TITLE
Auto-schedule: start cursor at current time on today's column

### DIFF
--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -383,7 +383,11 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
       const j = Math.floor(seededRandom(seed + i) * (i + 1));
       [ordered[i], ordered[j]] = [ordered[j], ordered[i]];
     }
-    let cursor = windowStart;
+    // For today's column, never schedule before the current time
+    const now = new Date();
+    const nowMins = now.getHours() * 60 + now.getMinutes();
+    const isToday = date === toLocalDateStr(now);
+    let cursor = isToday ? Math.max(windowStart, snapMinutes(nowMins)) : windowStart;
     const updates = [];
     for (const task of ordered) {
       const dur = task.duration || 30;


### PR DESCRIPTION
Never place tasks before 'now' when auto-scheduling. For today's column the cursor starts at max(windowStart, snapMinutes(nowMins)); for future days it still starts from windowStart as before.

https://claude.ai/code/session_01EBZq2ddn3oVzJfTRNTusGi