### PR TITLE
Railway: PostgreSQL DATABASE_URL and psycopg2

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,8 @@
 # Copy this file to .env and fill in your values
 
+# Database (optional: defaults to backend/ztd.db for SQLite; set in production e.g. Railway PostgreSQL)
+# DATABASE_URL=postgresql://user:pass@host:5432/dbname
+
 # JWT secret key - change this to a long random string in production
 JWT_SECRET_KEY=change-me-to-a-long-random-secret
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -20,11 +20,23 @@ app = Flask(__name__)
 CORS(app)
 
 # --- Configuration ---
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv(
-    'DATABASE_URL',
-    f"sqlite:///{os.path.join(BASE_DIR, 'ztd.db')}"
-)
+
+
+def _sqlalchemy_database_uri() -> str:
+    """Local dev uses SQLite; use DATABASE_URL (e.g. Railway Postgres) in production."""
+    default_sqlite = f"sqlite:///{os.path.join(BASE_DIR, 'ztd.db')}"
+    url = os.getenv("DATABASE_URL", default_sqlite)
+    # Heroku / Railway: postgres:// is deprecated in SQLAlchemy; normalize to postgresql+psycopg2
+    if url.startswith("postgres://"):
+        return "postgresql+psycopg2://" + url.removeprefix("postgres://")
+    if url.startswith("postgresql://"):
+        return "postgresql+psycopg2://" + url.removeprefix("postgresql://")
+    return url
+
+
+app.config["SQLALCHEMY_DATABASE_URI"] = _sqlalchemy_database_uri()
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['JWT_SECRET_KEY'] = os.getenv('JWT_SECRET_KEY', 'dev-secret-change-in-production')
 app.config['JWT_ACCESS_TOKEN_EXPIRES'] = timedelta(days=30)

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 import os
 import re
 import json
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from datetime import datetime, timedelta
 import dateparser
 import stripe
@@ -30,9 +31,19 @@ def _sqlalchemy_database_uri() -> str:
     url = os.getenv("DATABASE_URL", default_sqlite)
     # Heroku / Railway: postgres:// is deprecated in SQLAlchemy; normalize to postgresql+psycopg2
     if url.startswith("postgres://"):
-        return "postgresql+psycopg2://" + url.removeprefix("postgres://")
-    if url.startswith("postgresql://"):
-        return "postgresql+psycopg2://" + url.removeprefix("postgresql://")
+        url = "postgresql+psycopg2://" + url.removeprefix("postgres://")
+    elif url.startswith("postgresql://") and not url.startswith("postgresql+psycopg2://"):
+        url = "postgresql+psycopg2://" + url.removeprefix("postgresql://")
+    if url.startswith("postgresql+psycopg2://"):
+        parts = urlsplit(url)
+        q = dict(parse_qsl(parts.query, keep_blank_values=True))
+        ssl = os.getenv("DATABASE_SSLMODE", "require")
+        if "sslmode" not in q and ssl and ssl.lower() != "disable":
+            q["sslmode"] = ssl
+        if q and urlencode(q) != parts.query:
+            url = urlunsplit(
+                (parts.scheme, parts.netloc, parts.path, urlencode(q), parts.fragment)
+            )
     return url
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,7 @@ dateparser==1.2.2
 python-dateutil==2.9.0.post0
 Flask-SQLAlchemy==3.1.1
 Flask-JWT-Extended==4.6.0
+psycopg2-binary==2.9.10
 stripe==8.11.0
 python-dotenv==1.0.0
 gunicorn==21.2.0

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,0 +1,12 @@
+import logging
+
+logger = logging.getLogger("gunicorn.error")
+
+
+def post_worker_init(_worker) -> None:
+    """Run after each worker is forked. Keep wsgi import free of DB I/O."""
+    from backend.app import app, db
+
+    with app.app_context():
+        db.create_all()
+    logger.info("Database tables ensured (db.create_all).")

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -2,4 +2,4 @@
 nixPkgs = ["python311"]
 
 [start]
-cmd = "gunicorn --bind 0.0.0.0:$PORT --workers 2 wsgi:app"
+cmd = "gunicorn -c gunicorn_config.py --bind 0.0.0.0:$PORT --workers 2 wsgi:app"

--- a/railway.toml
+++ b/railway.toml
@@ -2,6 +2,6 @@
 builder = "nixpacks"
 
 [deploy]
-startCommand = "gunicorn --bind 0.0.0.0:$PORT --workers 2 wsgi:app"
+startCommand = "gunicorn -c gunicorn_config.py --bind 0.0.0.0:$PORT --workers 2 wsgi:app"
 healthcheckPath = "/api/health"
 restartPolicyType = "on_failure"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==3.0.0
 flask-cors==4.0.0
 Flask-SQLAlchemy==3.1.1
 Flask-JWT-Extended==4.6.0
+psycopg2-binary==2.9.10
 stripe==8.11.0
 python-dotenv==1.0.0
 gunicorn==21.2.0

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,5 @@
-from backend.app import app, db
+# Import must stay lightweight: gunicorn loads this before workers are ready;
+# table creation is deferred to gunicorn_config.post_worker_init.
+from backend.app import app, db  # noqa: F401  — 'db' used by gunicorn_config
 
-with app.app_context():
-    db.create_all()
+__all__ = ("app", "db")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This PR makes the Flask app work with Railway’s PostgreSQL add-on by normalizing `DATABASE_URL` (including the legacy `postgres://` form) to SQLAlchemy + `psycopg2`, and adds the `psycopg2-binary` dependency to both root and `backend` requirements so deploys that only install from `backend/requirements.txt` also get the driver.

## How to deploy on Railway (this repo)
The project already has **two** Railway-style configs: API at the repo root (`railway.toml`, gunicorn `wsgi:app`, health at `/api/health`) and the React static app in `frontend/` with its own `frontend/railway.toml`.

1. **API (service from repo root)**  
   - Connect the repo and use the default root.  
   - **Add a PostgreSQL** plugin in Railway and link it to this service (sets `DATABASE_URL` automatically).  
   - Set secrets as in `backend/.env.example`: at minimum a strong `JWT_SECRET_KEY`, and for Stripe/redirects set `FRONTEND_URL` to your frontend public URL, plus the Stripe keys if you use billing.  
   - For Stripe, point the webhook to `https://&lt;your-api-host&gt;/api/stripe/webhook`.

2. **Frontend (second service, root directory `frontend/`)**  
   - Add another service from the same repo with **Root Directory** = `frontend`.  
   - Set a **build** variable: `REACT_APP_API_URL=https://&lt;your-api-host&gt;/api` (must include `/api` because the client uses it as a base; CRA bakes it in at build, so **redeploy** if you change it).  
   - CORS is already open on the API for cross-origin use.

Local development still defaults to SQLite under `backend/` when `DATABASE_URL` is unset.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b79e23e-45bf-415d-ab70-7ed667bb449c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b79e23e-45bf-415d-ab70-7ed667bb449c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

