### PR TITLE
fix(frontend): bind serve on 0.0.0.0 for Railway healthcheck

### DIFF
--- a/frontend/nixpacks.toml
+++ b/frontend/nixpacks.toml
@@ -5,4 +5,4 @@ cmds = ["npm install", "npm install -g serve"]
 cmds = ["npm run build"]
 
 [start]
-cmd = "serve -s build -l $PORT"
+cmd = "serve -s build -l tcp://0.0.0.0:$PORT"

--- a/frontend/railway.toml
+++ b/frontend/railway.toml
@@ -2,6 +2,7 @@
 builder = "nixpacks"
 
 [deploy]
-startCommand = "serve -s build -l $PORT"
+# Bind all interfaces — plain "-l $PORT" can listen on localhost only, so Railway's healthcheck fails
+startCommand = "serve -s build -l tcp://0.0.0.0:$PORT"
 healthcheckPath = "/"
 restartPolicyType = "on_failure"


### PR DESCRIPTION
serve -l PORT can listen on localhost; Railway needs all interfaces