### PR TITLE
Fix account creation: serve React build from Flask for single-service…

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import text
@@ -789,6 +789,17 @@ def migrate_db():
                 except Exception:
                     pass  # column already exists
             conn.commit()
+
+
+_FRONTEND_BUILD = os.path.join(BASE_DIR, '..', 'frontend', 'build')
+
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>')
+def serve_frontend(path):
+    full = os.path.join(_FRONTEND_BUILD, path)
+    if path and os.path.isfile(full):
+        return send_from_directory(_FRONTEND_BUILD, path)
+    return send_from_directory(_FRONTEND_BUILD, 'index.html')
 
 
 if __name__ == '__main__':

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,11 @@
 [phases.setup]
-nixPkgs = ["python311"]
+nixPkgs = ["python311", "nodejs_18"]
+
+[phases.install]
+cmds = ["pip install -r requirements.txt", "cd frontend && npm ci"]
+
+[phases.build]
+cmds = ["cd frontend && npm run build"]
 
 [start]
 cmd = "gunicorn -c gunicorn_config.py --bind 0.0.0.0:$PORT --workers 2 wsgi:app"


### PR DESCRIPTION
… Railway deploy

- nixpacks.toml: add Node 18, run npm ci + npm run build during deployment so the React bundle is available when the Flask process starts
- backend/app.py: add catch-all route that serves frontend/build/* for non-API paths; REACT_APP_API_URL defaults to relative /api which now correctly resolves to the same-origin Flask backend

https://claude.ai/code/session_01HMLsSbAiQgFMGxvkx7LKR8