### PR TITLE
Improve Railway auth/API endpoint misconfiguration errors

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -7,7 +7,7 @@ function normalizeApiBase(raw) {
     return `${protocol}${value}`.replace(/\/$/, '');
   }
   // Common Railway misconfig: "my-api.up.railway.app/api" (missing protocol)
-  if (/^[\w.-]+(?:\:\d+)?(\/.*)?$/.test(value) && !value.startsWith('/')) {
+  if (/^[\w.-]+(?::\d+)?(\/.*)?$/.test(value) && !value.startsWith('/')) {
     const prefixed = value.startsWith('localhost') || value.startsWith('127.0.0.1')
       ? `http://${value}`
       : `https://${value}`;
@@ -17,6 +17,16 @@ function normalizeApiBase(raw) {
 }
 
 const API_URL = normalizeApiBase(process.env.REACT_APP_API_URL || '/api');
+const IS_RAILWAY_HOST =
+  typeof window !== 'undefined' && /\.up\.railway\.app$/i.test(window.location.hostname);
+
+function railwayApiHint() {
+  if (!IS_RAILWAY_HOST) return '';
+  return (
+    ' Railway fix: set REACT_APP_API_URL to your backend service public domain with /api ' +
+    '(example: https://your-backend.up.railway.app/api), then redeploy the frontend.'
+  );
+}
 
 /** Avoid infinite loading if the API never responds (wrong URL, CORS hang, etc.) */
 const FETCH_TIMEOUT_MS = 30000;
@@ -63,7 +73,7 @@ async function apiFetch(path, options = {}) {
         (typeof window !== 'undefined' &&
           process.env.REACT_APP_API_URL == null &&
           !/\/localhost(?::\d+)?$/.test(window.location.host))
-          ? ' Set REACT_APP_API_URL in your hosting build to your public API base URL, including /api (then redeploy the frontend).'
+          ? ` Set REACT_APP_API_URL in your hosting build to your public API base URL, including /api (then redeploy the frontend).${railwayApiHint()}`
           : ' Check that the API is running and CORS is allowed for this site.';
       throw new Error(
         `Cannot reach the server (${url}).${hint} (${e.message || 'network'})`
@@ -94,7 +104,7 @@ async function apiFetch(path, options = {}) {
       new Error(
         `${prefix} Expected JSON but received HTML from ${url}. ` +
         'This usually means REACT_APP_API_URL points to the frontend URL (or missing /api), ' +
-        'or your host rewrote /api/* to index.html.'
+        `or your host rewrote /api/* to index.html.${railwayApiHint()}`
       ),
       { status: res.status, data: { raw: raw.slice(0, 200) } }
     );


### PR DESCRIPTION
### Motivation
- Provide clearer, actionable error messages when the frontend is hosted on Railway and the API URL is misconfigured or the frontend host rewrote `/api/*` to the SPA.

### Description
- Added Railway host detection and a helper `railwayApiHint()` to supply a Railway-specific fix suggesting `REACT_APP_API_URL` point to the backend public domain with `/api` (file: `frontend/src/api.js`).
- Appended the Railway hint to the network-failure message shown when `fetch` fails and `REACT_APP_API_URL` is missing, and to the HTML-response error thrown when an API call receives HTML instead of JSON (file: `frontend/src/api.js`).
- Fixed a minor regex to remove an unnecessary escape in the `normalizeApiBase` host detection logic (file: `frontend/src/api.js`).

### Testing
- Ran `npm run build` in `frontend/` which initially produced an ESLint warning and after the regex fix completed successfully. The production build compiled successfully and produced the `build/` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeddfba9348331a4a608f81996d455)