### PR TITLE
Timebox: drag-and-drop from task sidebar to grid + unschedule button

### DIFF
--- a/frontend/src/components/TimeboxView.css
+++ b/frontend/src/components/TimeboxView.css
@@ -60,6 +60,20 @@
   background: rgba(255, 255, 255, 0.06);
   border-radius: 8px;
   border-left: 2px solid rgba(255, 255, 255, 0.15);
+  cursor: grab;
+}
+
+.timebox-sidebar-chip:active { cursor: grabbing; }
+
+.timebox-drag-preview {
+  position: absolute;
+  left: 40px;
+  right: 4px;
+  background: rgba(102, 126, 234, 0.2);
+  border: 2px dashed rgba(102, 126, 234, 0.6);
+  border-radius: 8px;
+  pointer-events: none;
+  z-index: 9;
 }
 
 .timebox-sidebar-chip.priority-urgent { border-left-color: #f87171; }
@@ -485,12 +499,17 @@
 .timebox-task-body {
   flex: 1;
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+  flex-direction: column;
   padding: 3px 6px;
-  gap: 4px;
+  gap: 2px;
   overflow: hidden;
   min-height: 0;
+}
+
+.timebox-task-top-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 3px;
 }
 
 .timebox-task-desc {
@@ -503,6 +522,22 @@
   -webkit-box-orient: vertical;
   flex: 1;
 }
+
+.timebox-task-unschedule {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.2);
+  font-size: 13px;
+  line-height: 1;
+  padding: 0 1px;
+  cursor: pointer;
+  border-radius: 3px;
+  flex-shrink: 0;
+  transition: color 0.12s;
+  margin-top: -1px;
+}
+
+.timebox-task-unschedule:hover { color: rgba(255, 80, 80, 0.8); }
 
 .timebox-task-meta {
   display: flex;

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -348,6 +348,7 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
   const [pendingSlot, setPendingSlot] = useState(null); // shown after drag ends
   const [unscheduledOpen, setUnscheduledOpen] = useState(true);
   const [editingTask, setEditingTask] = useState(null);
+  const [dragOverMins, setDragOverMins] = useState(null); // HTML5 drag-from-sidebar preview
 
   // Refs so drag handlers always read the latest state without re-registering listeners
   const localTasksRef = useRef(localTasks);
@@ -532,6 +533,41 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
     onBlockedTimesChange(next);
   };
 
+  // ── HTML5 drag-from-sidebar handlers ──────────────────────────────────────
+  const handleGridDragOver = (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    if (!wrapperRef.current) return;
+    const y = getRelativeY(e, wrapperRef.current);
+    const mins = snapMinutes(Math.max(0, Math.min(1439, yToMinutes(y))));
+    setDragOverMins(mins);
+  };
+
+  const handleGridDragLeave = () => setDragOverMins(null);
+
+  const handleGridDrop = async (e) => {
+    e.preventDefault();
+    setDragOverMins(null);
+    const taskJson = e.dataTransfer.getData('application/task-json');
+    if (!taskJson || !wrapperRef.current) return;
+    const task = JSON.parse(taskJson);
+    const y = getRelativeY(e, wrapperRef.current);
+    const mins = snapMinutes(Math.max(windowStart, Math.min(windowEnd - (task.duration || 30), yToMinutes(y))));
+    const updates = { scheduled_time: formatTime(mins), scheduled_date: date };
+    setLocalTasks(prev => {
+      const exists = prev.some(t => t.id === task.id);
+      if (exists) return prev.map(t => t.id === task.id ? { ...t, ...updates } : t);
+      return [...prev, { ...task, ...updates }];
+    });
+    await onUpdateTask(task.id, updates);
+  };
+
+  const handleUnschedule = async (task) => {
+    const updates = { scheduled_time: null, scheduled_date: null };
+    setLocalTasks(prev => prev.map(t => t.id === task.id ? { ...t, ...updates } : t));
+    await onUpdateTask(task.id, updates);
+  };
+
   // ── Render ─────────────────────────────────────────────────────────────────
   const hourLabels = Array.from({ length: 24 }, (_, h) => h);
   const dateBlockedForDay = blockedTimes.filter(b => b.date === date);
@@ -552,9 +588,18 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
       </div>
 
       {/* Grid */}
-      <div className="timebox-grid-wrapper" ref={wrapperRef}>
+      <div className="timebox-grid-wrapper" ref={wrapperRef}
+        onDragOver={handleGridDragOver}
+        onDrop={handleGridDrop}
+        onDragLeave={handleGridDragLeave}
+      >
         <div className="timebox-grid" ref={gridRef} onMouseDown={handleGridMouseDown}
           style={{ height: GRID_HEIGHT }}>
+
+          {/* Drag-from-sidebar preview */}
+          {dragOverMins !== null && (
+            <div className="timebox-drag-preview" style={{ top: dragOverMins * PX_PER_MIN, height: 30 * PX_PER_MIN }} />
+          )}
 
           {/* Hour lines + labels */}
           {hourLabels.map(h => (
@@ -646,7 +691,14 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
                   }, e)}
                 />
                 <div className="timebox-task-body">
-                  <span className="timebox-task-desc">{task.description}</span>
+                  <div className="timebox-task-top-row">
+                    <span className="timebox-task-desc">{task.description}</span>
+                    <button
+                      className="timebox-task-unschedule"
+                      onClick={(e) => { e.stopPropagation(); handleUnschedule(task); }}
+                      title="Remove from schedule"
+                    >×</button>
+                  </div>
                   <div className="timebox-task-meta">
                     <span className="timebox-task-duration">{task.duration || 30}m</span>
                     <button
@@ -817,13 +869,19 @@ function TimeboxView({ tasks, hats, onUpdate, onAddTask, maxHistoryDays = 14 }) 
                   <div
                     key={task.id}
                     className={`timebox-sidebar-chip priority-${task.priority || 'none'} ${mitIds.has(task.id) ? 'mit' : ''}`}
+                    draggable
+                    onDragStart={(e) => {
+                      e.dataTransfer.setData('application/task-json', JSON.stringify(task));
+                      e.dataTransfer.effectAllowed = 'move';
+                    }}
+                    title="Drag onto the grid to schedule"
                   >
                     <span className="timebox-chip-desc">{task.description}</span>
                     <div className="timebox-chip-row">
                       <span className="timebox-chip-dur">{task.duration || 30}m</span>
                       <button
                         className={`timebox-mit-btn ${mitIds.has(task.id) ? 'active' : ''} ${!mitIds.has(task.id) && mitIds.size >= 3 ? 'disabled' : ''}`}
-                        onClick={() => handleToggleMit(task.id)}
+                        onClick={(e) => { e.stopPropagation(); handleToggleMit(task.id); }}
                         title="Toggle Most Important Task"
                       >⭐</button>
                     </div>


### PR DESCRIPTION
- Sidebar chips are now draggable; drag onto the timebox grid to schedule at the dropped time (snapped to 15m, clamped to window)
- Blue dashed ghost preview shows where the task will land
- Each scheduled task block now has an × button to move it back to the task pool (clears scheduled_time and scheduled_date)
- Fix task block body layout to accommodate the × button

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw