### PR TITLE
Timebox: restore edit, lift modal to TimeboxView level

### DIFF
--- a/frontend/src/components/TimeboxView.css
+++ b/frontend/src/components/TimeboxView.css
@@ -499,17 +499,12 @@
 .timebox-task-body {
   flex: 1;
   display: flex;
-  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
   padding: 3px 6px;
-  gap: 2px;
+  gap: 4px;
   overflow: hidden;
   min-height: 0;
-}
-
-.timebox-task-top-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 3px;
 }
 
 .timebox-task-desc {
@@ -523,20 +518,21 @@
   flex: 1;
 }
 
+.timebox-task-edit-btn,
 .timebox-task-unschedule {
   background: none;
   border: none;
-  color: rgba(255, 255, 255, 0.2);
-  font-size: 13px;
+  color: rgba(255, 255, 255, 0.25);
+  font-size: 11px;
   line-height: 1;
-  padding: 0 1px;
+  padding: 1px 2px;
   cursor: pointer;
   border-radius: 3px;
   flex-shrink: 0;
   transition: color 0.12s;
-  margin-top: -1px;
 }
 
+.timebox-task-edit-btn:hover { color: rgba(150, 200, 255, 0.9); }
 .timebox-task-unschedule:hover { color: rgba(255, 80, 80, 0.8); }
 
 .timebox-task-meta {

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -338,17 +338,16 @@ function TaskEditModal({ task, hats, onSave, onClose }) {
 }
 
 // ── TimeboxDayColumn ─────────────────────────────────────────────────────────
-function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blockedTimes, onBlockedTimesChange, mitIds, onToggleMit, onUpdateTask, onAddTask, isWeekView, shuffleSeed, onShuffle }) {
+function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blockedTimes, onBlockedTimesChange, mitIds, onToggleMit, onUpdateTask, onAddTask, isWeekView, shuffleSeed, onShuffle, onEditTask }) {
   const gridRef = useRef(null);
   const wrapperRef = useRef(null);
   const [dragging, setDragging] = useState(null);
   const [localTasks, setLocalTasks] = useState(tasks);
   const [localWindow, setLocalWindow] = useState(dayWindow);
-  const [blockDrag, setBlockDrag] = useState(null); // { startMin, endMin, screenX, screenY }
-  const [pendingSlot, setPendingSlot] = useState(null); // shown after drag ends
+  const [blockDrag, setBlockDrag] = useState(null);
+  const [pendingSlot, setPendingSlot] = useState(null);
   const [unscheduledOpen, setUnscheduledOpen] = useState(true);
-  const [editingTask, setEditingTask] = useState(null);
-  const [dragOverMins, setDragOverMins] = useState(null); // HTML5 drag-from-sidebar preview
+  const [dragOverMins, setDragOverMins] = useState(null);
 
   // Refs so drag handlers always read the latest state without re-registering listeners
   const localTasksRef = useRef(localTasks);
@@ -691,21 +690,27 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
                   }, e)}
                 />
                 <div className="timebox-task-body">
-                  <div className="timebox-task-top-row">
-                    <span className="timebox-task-desc">{task.description}</span>
-                    <button
-                      className="timebox-task-unschedule"
-                      onClick={(e) => { e.stopPropagation(); handleUnschedule(task); }}
-                      title="Remove from schedule"
-                    >×</button>
-                  </div>
+                  <span className="timebox-task-desc">{task.description}</span>
                   <div className="timebox-task-meta">
                     <span className="timebox-task-duration">{task.duration || 30}m</span>
                     <button
+                      className="timebox-task-edit-btn"
+                      onMouseDown={(e) => e.stopPropagation()}
+                      onClick={(e) => { e.stopPropagation(); onEditTask(task); }}
+                      title="Edit task"
+                    >✎</button>
+                    <button
                       className={`timebox-mit-btn ${isMit ? 'active' : ''} ${!isMit && mitIds.size >= 3 ? 'disabled' : ''}`}
+                      onMouseDown={(e) => e.stopPropagation()}
                       onClick={(e) => { e.stopPropagation(); onToggleMit(task.id); }}
                       title={isMit ? 'Remove from MIT' : 'Mark as Most Important Task'}
                     >⭐</button>
+                    <button
+                      className="timebox-task-unschedule"
+                      onMouseDown={(e) => e.stopPropagation()}
+                      onClick={(e) => { e.stopPropagation(); handleUnschedule(task); }}
+                      title="Remove from schedule"
+                    >×</button>
                   </div>
                 </div>
                 <div
@@ -733,19 +738,6 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
         />
       )}
 
-      {/* Task edit modal */}
-      {editingTask && (
-        <TaskEditModal
-          task={editingTask}
-          hats={hats}
-          onSave={async (id, data) => {
-            setLocalTasks(prev => prev.map(t => t.id === id ? { ...t, ...data } : t));
-            await onUpdateTask(id, data);
-            setEditingTask(null);
-          }}
-          onClose={() => setEditingTask(null)}
-        />
-      )}
 
       {/* Task pool — all unscheduled tasks (always shown in day view / today's week col) */}
       {showTaskPool && (
@@ -789,7 +781,8 @@ function TimeboxView({ tasks, hats, onUpdate, onAddTask, maxHistoryDays = 14 }) 
   const [dayWindows, setDayWindows] = useState(loadDayWindows);
   const [blockedTimes, setBlockedTimes] = useState(loadBlockedTimes);
   const [shuffleSeed, setShuffleSeed] = useState(0);
-  const [weekStartOffset, setWeekStartOffset] = useState(0); // days from today
+  const [weekStartOffset, setWeekStartOffset] = useState(0);
+  const [editingTask, setEditingTask] = useState(null);
 
   const today = toLocalDateStr(new Date());
   const weekDates = getWeekDates(weekStartOffset);
@@ -847,10 +840,22 @@ function TimeboxView({ tasks, hats, onUpdate, onAddTask, maxHistoryDays = 14 }) 
     onAddTask,
     shuffleSeed,
     onShuffle: handleShuffle,
+    onEditTask: setEditingTask,
   };
 
   return (
     <div className="timebox-container">
+      {editingTask && (
+        <TaskEditModal
+          task={editingTask}
+          hats={hats}
+          onSave={async (id, data) => {
+            await onUpdate(id, data);
+            setEditingTask(null);
+          }}
+          onClose={() => setEditingTask(null)}
+        />
+      )}
       <div className="timebox-subview-toggle">
         <button className={`timebox-sub-btn ${subView === 'day' ? 'active' : ''}`} onClick={() => setSubView('day')}>Day</button>
         <button className={`timebox-sub-btn ${subView === 'week' ? 'active' : ''}`} onClick={() => setSubView('week')}>Week</button>
@@ -879,6 +884,11 @@ function TimeboxView({ tasks, hats, onUpdate, onAddTask, maxHistoryDays = 14 }) 
                     <span className="timebox-chip-desc">{task.description}</span>
                     <div className="timebox-chip-row">
                       <span className="timebox-chip-dur">{task.duration || 30}m</span>
+                      <button
+                        className="timebox-task-edit-btn"
+                        onClick={(e) => { e.stopPropagation(); setEditingTask(task); }}
+                        title="Edit task"
+                      >✎</button>
                       <button
                         className={`timebox-mit-btn ${mitIds.has(task.id) ? 'active' : ''} ${!mitIds.has(task.id) && mitIds.size >= 3 ? 'disabled' : ''}`}
                         onClick={(e) => { e.stopPropagation(); handleToggleMit(task.id); }}


### PR DESCRIPTION
- Move editingTask state + TaskEditModal from TimeboxDayColumn up to TimeboxView so both the grid tasks and sidebar chips can open it
- Add visible ✎ edit button on each grid task block (single click)
- Add ✎ edit button on each sidebar chip
- Add stopPropagation on all action button mousedown events so they don't accidentally start a drag operation
- Revert task-body to single-row flex layout (column was too cramped for 30-minute task blocks at 32px height)
- All three buttons (✎ edit, ⭐ MIT, × unschedule) now work correctly

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw