### PR TITLE
Add PREMIUM_USERS fallback in /api/health + diagnostic prints

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -770,8 +770,30 @@ def get_subscription():
     return jsonify(result)
 
 
+_premium_users_applied = False
+
+
 @app.route('/api/health', methods=['GET'])
 def health():
+    global _premium_users_applied
+    if not _premium_users_applied:
+        _premium_users_applied = True
+        try:
+            raw = os.environ.get("PREMIUM_USERS") or ""
+            emails = [e.strip().lower() for e in raw.split(",") if e.strip()]
+            print(f"[health/PREMIUM_USERS] env={raw!r}", flush=True)
+            for email in emails:
+                user = User.query.filter_by(email=email).first()
+                if user is None:
+                    print(f"[health/PREMIUM_USERS] no account for {email}", flush=True)
+                elif user.tier != "premium":
+                    user.tier = "premium"
+                    db.session.commit()
+                    print(f"[health/PREMIUM_USERS] upgraded {email} -> premium", flush=True)
+                else:
+                    print(f"[health/PREMIUM_USERS] {email} already premium", flush=True)
+        except Exception as e:
+            print(f"[health/PREMIUM_USERS] error: {e}", flush=True)
     return jsonify({'status': 'ok'})
 
 

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,11 +1,15 @@
 import logging
 import os
+import sys
 
 logger = logging.getLogger("gunicorn.error")
+
+print("[gunicorn_config] module loaded", file=sys.stderr, flush=True)
 
 
 def post_worker_init(_worker) -> None:
     """Run after each worker is forked. Keep wsgi import free of DB I/O."""
+    print("[gunicorn_config] post_worker_init starting", file=sys.stderr, flush=True)
     from backend.app import app, db, User
     from backend.bootstrap import ensure_bootstrap_admin
 
@@ -14,15 +18,17 @@ def post_worker_init(_worker) -> None:
         ensure_bootstrap_admin()
 
         raw = os.environ.get("PREMIUM_USERS") or ""
+        print(f"[PREMIUM_USERS] env var = {raw!r}", file=sys.stderr, flush=True)
         for email in [e.strip().lower() for e in raw.split(",") if e.strip()]:
             user = User.query.filter_by(email=email).first()
             if user is None:
-                logger.warning("PREMIUM_USERS: no account for %s, skipping.", email)
+                print(f"[PREMIUM_USERS] no account for {email}, skipping", file=sys.stderr, flush=True)
             elif user.tier != "premium":
                 user.tier = "premium"
                 db.session.commit()
-                logger.info("PREMIUM_USERS: upgraded %s → premium", email)
+                print(f"[PREMIUM_USERS] upgraded {email} -> premium", file=sys.stderr, flush=True)
             else:
-                logger.info("PREMIUM_USERS: %s already premium.", email)
+                print(f"[PREMIUM_USERS] {email} already premium", file=sys.stderr, flush=True)
 
     logger.info("Database tables ensured (db.create_all).")
+    print("[gunicorn_config] post_worker_init complete", file=sys.stderr, flush=True)


### PR DESCRIPTION
The startup-bootstrap mechanism wasn't producing any logs in Railway, so this adds a second path: the first call to /api/health (which Railway hits as its healthcheck) runs the PREMIUM_USERS upgrade and flushes prints to stderr so the result is visible.

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw