### PR TITLE
Add lock task in time feature + drag hop-over behavior

### DIFF
--- a/frontend/src/components/TimeboxView.css
+++ b/frontend/src/components/TimeboxView.css
@@ -597,14 +597,13 @@
   font-size: 9px;
   padding: 1px 2px;
   border-radius: 3px;
-  opacity: 0.2;
-  transition: opacity 0.15s, filter 0.15s;
+  opacity: 0.3;
+  transition: opacity 0.15s;
   line-height: 1;
-  filter: grayscale(1);
 }
 
-.timebox-lock-btn:hover { opacity: 0.6; filter: grayscale(0.4); }
-.timebox-lock-btn.active { opacity: 1; filter: grayscale(0); }
+.timebox-lock-btn:hover { opacity: 0.7; }
+.timebox-lock-btn.active { opacity: 1; }
 
 /* Locked task block */
 .timebox-task.locked {

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -79,6 +79,29 @@ function advancePastBlocked(cursorMin, durationMin, blockedTimes, date) {
   return cursor;
 }
 
+// During drag: if desired position overlaps a locked task, snap to the nearest
+// free slot (before or after the locked task), based on raw desired position.
+function snapAroundLocked(desiredMin, durationMin, lockedIntervals, date) {
+  let result = desiredMin;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const b of lockedIntervals) {
+      if (b.date !== date) continue;
+      const bs = parseMinutes(b.start);
+      const be = parseMinutes(b.end);
+      if (result < be && result + durationMin > bs) {
+        const before = bs - durationMin;
+        const after = be;
+        result = Math.abs(desiredMin - before) <= Math.abs(desiredMin - after) ? before : after;
+        changed = true;
+        break;
+      }
+    }
+  }
+  return result;
+}
+
 function seededRandom(seed) {
   const x = Math.sin(seed + 1) * 10000;
   return x - Math.floor(x);
@@ -516,7 +539,20 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
         const newMin = Math.max(wStart + 60, Math.min(1439, snapMinutes(dragging.origMin + deltaMins)));
         setLocalWindow(w => ({ ...w, end: formatTime(newMin) }));
       } else if (dragging.type === 'task-move') {
-        const newMin = Math.max(wStart, Math.min(wEnd - (dragging.duration || 30), snapMinutes(dragging.origMin + deltaMins)));
+        const dur = dragging.duration || 30;
+        let newMin = Math.max(wStart, Math.min(wEnd - dur, snapMinutes(dragging.origMin + deltaMins)));
+        // Hop over locked tasks — snap to nearest free slot (before or after)
+        const lockedIntervals = localTasksRef.current
+          .filter(t => t.id !== dragging.taskId && t.locked && t.scheduled_time)
+          .map(t => ({
+            date: t.scheduled_date || date,
+            start: t.scheduled_time,
+            end: formatTime(parseMinutes(t.scheduled_time) + (t.duration || 30)),
+          }));
+        if (lockedIntervals.length > 0) {
+          newMin = snapAroundLocked(newMin, dur, lockedIntervals, date);
+          newMin = Math.max(wStart, Math.min(wEnd - dur, newMin));
+        }
         setLocalTasks(prev => prev.map(t => t.id === dragging.taskId ? { ...t, scheduled_time: formatTime(newMin) } : t));
       } else if (dragging.type === 'task-resize-bottom') {
         const newEndMin = Math.max(dragging.origMin + SNAP, Math.min(wEnd, snapMinutes(dragging.origEndMin + deltaMins)));


### PR DESCRIPTION
## Summary

- **Lock button (🔒)** on each scheduled task block in Timebox view — click to lock/unlock a task in its time slot
- **Locked tasks can't be dragged or resized** — cursor changes to default, all drag handlers are disabled
- **Drag hop-over**: when dragging another task over a locked block, it automatically snaps to the nearest free slot (before or after) based on cursor position
- **Auto-schedule skips locked tasks** — treats them as additional blocked intervals when filling the day
- **Persisted** — `locked` column added to the Task model with automatic migration; toggling sends `PUT /api/tasks/:id` with `{ locked: true/false }`

## Test plan

- [ ] Schedule a task in Timebox, click 🔒 — block gets dashed border and cursor becomes default
- [ ] Try dragging a locked task — it should not move
- [ ] Drag another task over a locked block — it should snap to just before or just after
- [ ] Click Auto — locked tasks are treated as blocked time, other tasks schedule around them
- [ ] Refresh page — locked state persists

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw)_