### PR TITLE
Fix lock button visibility in Timebox task blocks

### DIFF
--- a/frontend/src/components/TimeboxView.css
+++ b/frontend/src/components/TimeboxView.css
@@ -591,19 +591,20 @@
 
 /* ── Lock button ────────────────────────────────────────────────────────────── */
 .timebox-lock-btn {
-  background: none;
-  border: none;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   cursor: pointer;
-  font-size: 9px;
-  padding: 1px 2px;
+  font-size: 10px;
+  padding: 1px 3px;
   border-radius: 3px;
-  opacity: 0.3;
-  transition: opacity 0.15s;
+  opacity: 0.55;
+  transition: opacity 0.15s, background 0.15s, border-color 0.15s;
   line-height: 1;
+  flex-shrink: 0;
 }
 
-.timebox-lock-btn:hover { opacity: 0.7; }
-.timebox-lock-btn.active { opacity: 1; }
+.timebox-lock-btn:hover { opacity: 0.9; background: rgba(255, 220, 80, 0.15); border-color: rgba(255,220,80,0.3); }
+.timebox-lock-btn.active { opacity: 1; background: rgba(255, 210, 60, 0.2); border-color: rgba(255,210,60,0.5); }
 
 /* Locked task block */
 .timebox-task.locked {

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -829,7 +829,7 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
                       onMouseDown={(e) => e.stopPropagation()}
                       onClick={(e) => { e.stopPropagation(); handleToggleLock(task); }}
                       title={isLocked ? 'Unlock task' : 'Lock task in time'}
-                    >🔒</button>
+                    >{isLocked ? '🔒' : '🔓'}</button>
                     <button
                       className={`timebox-mit-btn ${isMit ? 'active' : ''} ${!isMit && mitIds.size >= 3 ? 'disabled' : ''}`}
                       onMouseDown={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary

- Lock button now has a visible background + border (pill shape) instead of relying on emoji opacity alone
- Inactive: subtle white border pill at 55% opacity
- Hover: golden tint background
- Active (locked): golden glow with 🔒 emoji; unlocked shows 🔓

## Test plan

- [ ] Schedule a task → see 🔓 button in the task meta row (bordered pill)
- [ ] Click it → turns gold 🔒, task gets dashed border and can't be dragged
- [ ] Click again → returns to 🔓 unlocked state

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw)_