### PR TITLE
Fix lock button: move to absolute overlay on task block

### DIFF
--- a/frontend/src/components/TimeboxView.css
+++ b/frontend/src/components/TimeboxView.css
@@ -589,22 +589,29 @@
 .timebox-mit-btn.active { opacity: 1; }
 .timebox-mit-btn.disabled { opacity: 0.15; cursor: not-allowed; }
 
-/* ── Lock button ────────────────────────────────────────────────────────────── */
+/* ── Lock button — absolute overlay on task block ───────────────────────────── */
 .timebox-lock-btn {
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  position: absolute;
+  bottom: 6px;
+  right: 4px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   cursor: pointer;
   font-size: 10px;
   padding: 1px 3px;
   border-radius: 3px;
-  opacity: 0.55;
+  opacity: 0;
   transition: opacity 0.15s, background 0.15s, border-color 0.15s;
   line-height: 1;
-  flex-shrink: 0;
+  z-index: 8;
 }
 
-.timebox-lock-btn:hover { opacity: 0.9; background: rgba(255, 220, 80, 0.15); border-color: rgba(255,220,80,0.3); }
-.timebox-lock-btn.active { opacity: 1; background: rgba(255, 210, 60, 0.2); border-color: rgba(255,210,60,0.5); }
+/* Show on task hover */
+.timebox-task:hover .timebox-lock-btn { opacity: 0.7; }
+.timebox-task:hover .timebox-lock-btn:hover { opacity: 1; background: rgba(255, 210, 60, 0.2); border-color: rgba(255,210,60,0.5); }
+
+/* Always show (bright gold) when locked */
+.timebox-task.locked .timebox-lock-btn { opacity: 1; background: rgba(255, 210, 60, 0.25); border-color: rgba(255,210,60,0.6); }
 
 /* Locked task block */
 .timebox-task.locked {

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -825,12 +825,6 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
                       title="Edit task"
                     >✎</button>
                     <button
-                      className={`timebox-lock-btn ${isLocked ? 'active' : ''}`}
-                      onMouseDown={(e) => e.stopPropagation()}
-                      onClick={(e) => { e.stopPropagation(); handleToggleLock(task); }}
-                      title={isLocked ? 'Unlock task' : 'Lock task in time'}
-                    >{isLocked ? '🔒' : '🔓'}</button>
-                    <button
                       className={`timebox-mit-btn ${isMit ? 'active' : ''} ${!isMit && mitIds.size >= 3 ? 'disabled' : ''}`}
                       onMouseDown={(e) => e.stopPropagation()}
                       onClick={(e) => { e.stopPropagation(); onToggleMit(task.id); }}
@@ -844,6 +838,13 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
                     >×</button>
                   </div>
                 </div>
+                {/* Lock button — absolutely positioned so it's always visible */}
+                <button
+                  className={`timebox-lock-btn ${isLocked ? 'active' : ''}`}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={(e) => { e.stopPropagation(); handleToggleLock(task); }}
+                  title={isLocked ? 'Unlock task' : 'Lock task in time'}
+                >{isLocked ? '🔒' : '🔓'}</button>
                 <div
                   className="timebox-task-resize-bottom"
                   onMouseDown={(e) => { if (isLocked) return; startMouseDrag('task-resize-bottom', {


### PR DESCRIPTION
## Summary

The lock button was buried inside a cramped flex meta row that gets clipped by `overflow: hidden` on small task blocks. This PR moves it to an absolutely-positioned overlay:

- Hidden by default (opacity 0)
- Appears on task hover (opacity 0.7, bottom-right corner)
- Always visible gold when the task is locked
- Removed from the meta row so it no longer competes for space with other buttons

## Test plan

- [ ] Schedule a task → hover over the block → 🔓 appears bottom-right
- [ ] Click 🔓 → turns gold 🔒, block gets dashed border, can no longer be dragged
- [ ] Click 🔒 → returns to draggable 🔓 state
- [ ] Refresh → locked state persists

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw)_