### PR TITLE
URGENT: Fix missing tasks — migrate_db PostgreSQL transaction bug

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -879,19 +879,22 @@ def admin_set_tier():
 
 
 def migrate_db():
+    # Each statement runs in its own connection/transaction so a "column already
+    # exists" failure on one doesn't abort and roll back the others (PostgreSQL
+    # marks the whole transaction as aborted on any error).
     with app.app_context():
-        with db.engine.connect() as conn:
-            for stmt in [
-                'ALTER TABLE task ADD COLUMN duration INTEGER DEFAULT 30',
-                'ALTER TABLE task ADD COLUMN scheduled_time VARCHAR(5)',
-                'ALTER TABLE task ADD COLUMN scheduled_date VARCHAR(10)',
-                'ALTER TABLE task ADD COLUMN locked BOOLEAN DEFAULT FALSE',
-            ]:
-                try:
+        for stmt in [
+            'ALTER TABLE task ADD COLUMN duration INTEGER DEFAULT 30',
+            'ALTER TABLE task ADD COLUMN scheduled_time VARCHAR(5)',
+            'ALTER TABLE task ADD COLUMN scheduled_date VARCHAR(10)',
+            'ALTER TABLE task ADD COLUMN locked BOOLEAN DEFAULT FALSE',
+        ]:
+            try:
+                with db.engine.connect() as conn:
                     conn.execute(text(stmt))
-                except Exception:
-                    pass  # column already exists
-            conn.commit()
+                    conn.commit()
+            except Exception:
+                pass  # column already exists
 
 
 _FRONTEND_BUILD = os.path.join(BASE_DIR, '..', 'frontend', 'build')


### PR DESCRIPTION
## What broke and why

`migrate_db()` ran all ALTER TABLE statements in **one shared PostgreSQL transaction**. In PostgreSQL, any error in a transaction (e.g. "column already exists" for `duration`, `scheduled_time`, `scheduled_date` which were added in a prior deploy) marks the **entire** transaction aborted — all subsequent statements, including the `locked` column addition and the final `COMMIT`, are silently discarded.

Result: the `locked` column was never added to the `task` table, but the SQLAlchemy model expected it. Every `GET /api/tasks` query tried to `SELECT locked` → `ProgrammingError` → 500 error → empty task list in the UI.

## Fix

Each `ALTER TABLE` now runs in its **own connection and transaction**. A "column already exists" failure on one statement rolls back only that statement and the loop continues normally.

## Deploy

Merge immediately — Railway will redeploy the backend, `migrate_db()` will add the `locked` column on startup, and tasks will reappear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw)_