### PR TITLE
Fix ESLint no-unused-vars: remove stale 'today' variable

### DIFF
--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -917,7 +917,6 @@ function TimeboxView({ tasks, hats, onUpdate, onAddTask, maxHistoryDays = 14 }) 
   const [weekStartOffset, setWeekStartOffset] = useState(0);
   const [editingTask, setEditingTask] = useState(null);
 
-  const today = toLocalDateStr(new Date());
   const weekDates = getWeekDates(weekStartOffset);
 
   const canGoBack = weekStartOffset > -maxHistoryDays;


### PR DESCRIPTION
Leftover from the dayOffset refactor; replaced by selectedDay.

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw