### PR TITLE
EMERGENCY: Self-healing get_tasks — auto-migrate on schema error

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -414,7 +414,13 @@ def get_tasks():
             Task.due <= today,
         )
     )
-    tasks = q.order_by(Task.position, Task.id).all()
+    try:
+        tasks = q.order_by(Task.position, Task.id).all()
+    except Exception:
+        # Schema may be missing new columns — run migration then retry
+        db.session.rollback()
+        migrate_db()
+        tasks = q.order_by(Task.position, Task.id).all()
     return jsonify([t.to_dict() for t in tasks])
 
 


### PR DESCRIPTION
## Emergency fix: tasks not loading

`GET /api/tasks` now catches any schema error (e.g. missing `locked` column), runs `migrate_db()` inline to add the missing column, then retries the query. Tasks will load immediately on the first request after deploy without waiting for the startup migration hook.

Merge immediately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw)_