### PR TITLE
Fix task block buttons: restore all buttons to meta row with proper visibility

### DIFF
--- a/frontend/src/components/TimeboxView.css
+++ b/frontend/src/components/TimeboxView.css
@@ -531,7 +531,7 @@
 .timebox-task-unschedule {
   background: none;
   border: none;
-  color: rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.55);
   font-size: 11px;
   line-height: 1;
   padding: 1px 2px;
@@ -541,15 +541,21 @@
   transition: color 0.12s;
 }
 
-.timebox-task-edit-btn:hover { color: rgba(150, 200, 255, 0.9); }
-.timebox-task-unschedule:hover { color: rgba(255, 80, 80, 0.8); }
+.timebox-task-edit-btn:hover { color: rgba(150, 200, 255, 1); }
+.timebox-task-unschedule:hover { color: rgba(255, 100, 100, 1); }
 
 .timebox-task-meta {
   display: flex;
   align-items: center;
   gap: 3px;
   flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
 }
+
+/* Show action buttons on hover; always show when locked so state is obvious */
+.timebox-task:hover .timebox-task-meta { opacity: 1; }
+.timebox-task.locked .timebox-task-meta { opacity: 1; }
 
 .timebox-task-duration {
   font-size: 9px;
@@ -589,35 +595,27 @@
 .timebox-mit-btn.active { opacity: 1; }
 .timebox-mit-btn.disabled { opacity: 0.15; cursor: not-allowed; }
 
-/* ── Lock button — absolute overlay on task block ───────────────────────────── */
+/* ── Lock button (inline in meta row) ───────────────────────────────────────── */
 .timebox-lock-btn {
-  position: absolute;
-  bottom: 6px;
-  right: 4px;
-  background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: none;
+  border: none;
   cursor: pointer;
-  font-size: 10px;
-  padding: 1px 3px;
+  font-size: 11px;
+  padding: 1px 2px;
   border-radius: 3px;
-  opacity: 0;
-  transition: opacity 0.15s, background 0.15s, border-color 0.15s;
+  opacity: 0.55;
+  transition: opacity 0.15s;
   line-height: 1;
-  z-index: 8;
+  flex-shrink: 0;
 }
 
-/* Show on task hover */
-.timebox-task:hover .timebox-lock-btn { opacity: 0.7; }
-.timebox-task:hover .timebox-lock-btn:hover { opacity: 1; background: rgba(255, 210, 60, 0.2); border-color: rgba(255,210,60,0.5); }
-
-/* Always show (bright gold) when locked */
-.timebox-task.locked .timebox-lock-btn { opacity: 1; background: rgba(255, 210, 60, 0.25); border-color: rgba(255,210,60,0.6); }
+.timebox-lock-btn:hover { opacity: 1; }
+.timebox-lock-btn.active { opacity: 1; }
 
 /* Locked task block */
 .timebox-task.locked {
   cursor: default !important;
   border-style: dashed;
-  opacity: 0.9;
 }
 
 .timebox-task.locked:active { cursor: default !important; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25); }

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -825,6 +825,12 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
                       title="Edit task"
                     >✎</button>
                     <button
+                      className={`timebox-lock-btn ${isLocked ? 'active' : ''}`}
+                      onMouseDown={(e) => e.stopPropagation()}
+                      onClick={(e) => { e.stopPropagation(); handleToggleLock(task); }}
+                      title={isLocked ? 'Unlock task' : 'Lock task in time'}
+                    >{isLocked ? '🔒' : '🔓'}</button>
+                    <button
                       className={`timebox-mit-btn ${isMit ? 'active' : ''} ${!isMit && mitIds.size >= 3 ? 'disabled' : ''}`}
                       onMouseDown={(e) => e.stopPropagation()}
                       onClick={(e) => { e.stopPropagation(); onToggleMit(task.id); }}
@@ -838,13 +844,6 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
                     >×</button>
                   </div>
                 </div>
-                {/* Lock button — absolutely positioned so it's always visible */}
-                <button
-                  className={`timebox-lock-btn ${isLocked ? 'active' : ''}`}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  onClick={(e) => { e.stopPropagation(); handleToggleLock(task); }}
-                  title={isLocked ? 'Unlock task' : 'Lock task in time'}
-                >{isLocked ? '🔒' : '🔓'}</button>
                 <div
                   className="timebox-task-resize-bottom"
                   onMouseDown={(e) => { if (isLocked) return; startMouseDrag('task-resize-bottom', {


### PR DESCRIPTION
## What was broken

The lock button was `position: absolute` with `opacity: 0` by default. This had two problems:
1. `overflow: hidden` on the task block clipped it in some configurations
2. `opacity: 0` made it completely invisible until hover — users couldn't discover it

The edit/unschedule buttons were at `rgba(255,255,255,0.25)` — barely visible on the dark task background.

## What this fixes

- Lock button moved back into the meta flex row (same row as ✎ ⭐ ×)
- All meta buttons hidden by default (`opacity: 0`), revealed on task hover
- Meta always visible when task is locked (so locked state is discoverable without hovering)
- Edit/X button contrast: 0.25 → 0.55
- Lock button: 0.55 opacity unlocked, 1.0 when locked

## Behavior

- Hover a task block → all action buttons appear (✎ 🔓 ⭐ ×)
- Click 🔓 → task locks (dashed border, 🔒 always visible, can't drag)
- Click 🔒 → unlocks

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw)_