### PR TITLE
Fix pool hiding tasks scheduled on other days; restore hat filter

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -527,7 +527,7 @@ function TaskApp() {
 
           {viewMode === 'timebox' && (
             <TimeboxView
-              tasks={tasks}
+              tasks={getVisibleTasks()}
               hats={hats}
               onUpdate={updateTask}
               onAddTask={addTask}

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -1125,8 +1125,18 @@ function TimeboxView({ tasks, hats, onUpdate, onAddTask, onApplyTaskUpdates, max
             <div className="timebox-task-sidebar-body">
               {(() => {
                 const taskSource = (dayOffset > 0 && futureTasks) ? futureTasks : tasks;
-                const pool = taskSource.filter(t => !t.scheduled_time && !dismissed.has(t.id));
-                const hasDismissed = taskSource.filter(t => !t.scheduled_time && dismissed.has(t.id)).length > 0;
+                const nextDayStr = addDays(selectedDay, 1);
+                // A task is "on today's grid" if it has a scheduled_time AND is placed on today
+                const isOnTodaysGrid = (t) => {
+                  if (!t.scheduled_time) return false;
+                  if (t.scheduled_date === selectedDay) return true;
+                  if (!t.scheduled_date && t.due === selectedDay) return true;
+                  if (t.scheduled_date === nextDayStr &&
+                      parseMinutes(t.scheduled_time) < OVERFLOW_HOURS * 60) return true;
+                  return false;
+                };
+                const pool = taskSource.filter(t => !isOnTodaysGrid(t) && !dismissed.has(t.id));
+                const hasDismissed = taskSource.filter(t => !isOnTodaysGrid(t) && dismissed.has(t.id)).length > 0;
                 return (
                   <>
                     {pool.length === 0 && !hasDismissed ? (


### PR DESCRIPTION
- Revert to getVisibleTasks() for hat-aware pool
- Pool now uses isOnTodaysGrid() check instead of bare !scheduled_time: tasks with stale scheduled_time from a past/future date resurface in the pool, while tasks actually placed on today's grid are still excluded

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw