### PR TITLE
Fix pool chip layout — restore task title visibility

### DIFF
--- a/frontend/src/components/TimeboxView.css
+++ b/frontend/src/components/TimeboxView.css
@@ -62,37 +62,30 @@
 }
 
 .timebox-sidebar-chip {
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 8px;
-  border-left: 2px solid rgba(255, 255, 255, 0.15);
-  overflow: hidden;
-}
-.timebox-chip-body {
-  flex: 1;
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 7px 9px;
-  position: relative;
+  padding: 7px 9px 7px 18px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  border-left: 2px solid rgba(255, 255, 255, 0.15);
   cursor: grab;
-  min-width: 0;
 }
-.timebox-chip-body:active { cursor: grabbing; }
+.timebox-sidebar-chip:active { cursor: grabbing; }
 
 .timebox-pool-drag-handle {
-  display: flex;
-  align-items: center;
-  padding: 0 5px;
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  transform: translateY(-50%);
   color: rgba(255, 255, 255, 0.2);
   font-size: 13px;
   cursor: grab;
   opacity: 0;
   transition: opacity 0.15s;
   user-select: none;
-  flex-shrink: 0;
+  line-height: 1;
 }
 .timebox-sidebar-chip:hover .timebox-pool-drag-handle { opacity: 1; }
 .timebox-pool-drag-handle:active { cursor: grabbing; }

--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -1049,11 +1049,10 @@ function TimeboxDayColumn({ date, tasks, hats, dayWindow, onWindowChange, blocke
 }
 
 // ── SortablePoolChip ─────────────────────────────────────────────────────────
-// The outer wrapper is the @dnd-kit item (setNodeRef). The handle span is inside
-// it but NOT inside any draggable element, so @dnd-kit pointer events work cleanly.
-// The chip-body div has HTML5 draggable for grid dropping.
 function SortablePoolChip({ task, hats, mitIds, onDismiss, onEdit, onToggleMit }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: task.id });
+  const handleRef = useRef(null);
+  const lastMouseDownTarget = useRef(null);
   const hat = hats?.find(h => h.id === task.hat_id);
   return (
     <div
@@ -1065,30 +1064,29 @@ function SortablePoolChip({ task, hats, mitIds, onDismiss, onEdit, onToggleMit }
         ...(hat?.color ? { borderLeft: `3px solid ${hat.color}` } : {}),
       }}
       className={`timebox-sidebar-chip priority-${task.priority || 'none'} ${mitIds.has(task.id) ? 'mit' : ''}`}
+      draggable
+      onMouseDown={(e) => { lastMouseDownTarget.current = e.target; }}
+      onDragStart={(e) => {
+        if (handleRef.current?.contains(lastMouseDownTarget.current)) {
+          e.preventDefault();
+          return;
+        }
+        e.dataTransfer.setData('application/task-json', JSON.stringify(task));
+        e.dataTransfer.effectAllowed = 'move';
+      }}
+      title="Drag onto the grid to schedule"
     >
-      {/* Handle — @dnd-kit only; NOT draggable so HTML5 drag won't fire */}
-      <span className="timebox-pool-drag-handle" {...attributes} {...listeners} title="Drag to reorder">⠿</span>
-      {/* Body — HTML5 draggable for dropping onto the grid */}
-      <div
-        className="timebox-chip-body"
-        draggable
-        onDragStart={(e) => {
-          e.dataTransfer.setData('application/task-json', JSON.stringify(task));
-          e.dataTransfer.effectAllowed = 'move';
-        }}
-        title="Drag onto the grid to schedule"
-      >
-        <button className="timebox-chip-dismiss" onClick={(e) => { e.stopPropagation(); onDismiss(task.id); }} title="Remove from today's pool">×</button>
-        <span className="timebox-chip-desc">{task.description}</span>
-        <div className="timebox-chip-row">
-          <span className="timebox-chip-dur">{task.duration || 30}m</span>
-          <button className="timebox-task-edit-btn" onClick={(e) => { e.stopPropagation(); onEdit(task); }} title="Edit task">✎</button>
-          <button
-            className={`timebox-mit-btn ${mitIds.has(task.id) ? 'active' : ''} ${!mitIds.has(task.id) && mitIds.size >= 3 ? 'disabled' : ''}`}
-            onClick={(e) => { e.stopPropagation(); onToggleMit(task.id); }}
-            title="Toggle Most Important Task"
-          >⭐</button>
-        </div>
+      <span ref={handleRef} className="timebox-pool-drag-handle" {...attributes} {...listeners} title="Drag to reorder">⠿</span>
+      <button className="timebox-chip-dismiss" onClick={(e) => { e.stopPropagation(); onDismiss(task.id); }} title="Remove from today's pool">×</button>
+      <span className="timebox-chip-desc">{task.description}</span>
+      <div className="timebox-chip-row">
+        <span className="timebox-chip-dur">{task.duration || 30}m</span>
+        <button className="timebox-task-edit-btn" onClick={(e) => { e.stopPropagation(); onEdit(task); }} title="Edit task">✎</button>
+        <button
+          className={`timebox-mit-btn ${mitIds.has(task.id) ? 'active' : ''} ${!mitIds.has(task.id) && mitIds.size >= 3 ? 'disabled' : ''}`}
+          onClick={(e) => { e.stopPropagation(); onToggleMit(task.id); }}
+          title="Toggle Most Important Task"
+        >⭐</button>
       </div>
     </div>
   );


### PR DESCRIPTION
Reverted SortablePoolChip from nested handle+body div structure back to a flat column layout. The nested div caused flex-direction:row which hid task descriptions. Now uses handleRef + lastMouseDownTarget to distinguish handle drags (@dnd-kit reorder) from body drags (HTML5 grid drop).

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw