### PR TITLE
Fix threads view navigation on narrow/half-screen widths

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -233,9 +233,17 @@
     display: block;
   }
 
-  /* In Threads mode: hide the main content, reveal the panel full-width */
-  .app-body--threads .container {
+  /* In Threads mode: keep the tab bar visible but hide only the view content */
+  .app-body--threads .view-content {
     display: none;
+  }
+
+  /* LooseThreads panel goes full-width in threads mode */
+  .app-body--threads .lt-panel {
+    width: 100%;
+    max-width: 100%;
+    position: static;
+    max-height: none;
   }
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -476,7 +476,7 @@ function TaskApp() {
             </button>
           </div>
 
-          {viewMode === 'active' && (
+          <div className="view-content">          {viewMode === 'active' && (
             <>
               {atLimit ? (
                 <div className="limit-banner">
@@ -539,8 +539,9 @@ function TaskApp() {
               maxHistoryDays={subscription?.tier === 'premium' ? 90 : 14}
             />
           )}
+          </div>{/* end view-content */}
         </div>
-        <LooseThreads onBack={viewMode === 'threads' ? () => setViewMode('active') : undefined} />
+        <LooseThreads />
       </div>
     </div>
   );

--- a/frontend/src/components/LooseThreads.css
+++ b/frontend/src/components/LooseThreads.css
@@ -38,23 +38,6 @@
   padding: 12px 0;
 }
 
-.lt-back-btn {
-  display: none;
-  background: none;
-  border: none;
-  color: rgba(255, 255, 255, 0.55);
-  font-size: 13px;
-  padding: 2px 6px;
-  cursor: pointer;
-  border-radius: 5px;
-  flex-shrink: 0;
-}
-.lt-back-btn:hover { color: rgba(255, 255, 255, 0.9); }
-
-@media (max-width: 900px) {
-  .lt-back-btn { display: block; }
-}
-
 .lt-panel-title {
   font-size: 13px;
   font-weight: 600;

--- a/frontend/src/components/LooseThreads.js
+++ b/frontend/src/components/LooseThreads.js
@@ -119,7 +119,7 @@ function NoteEditor({ note, onUpdate, onClose, onFontSize }) {
   );
 }
 
-export default function LooseThreads({ onBack }) {
+export default function LooseThreads() {
   const [notes,     setNotes]     = useState(() => load(STORAGE_KEY));
   const [trash,     setTrash]     = useState(() => load(TRASH_KEY));
   const [openIds,   setOpenIds]   = useState([]);
@@ -186,9 +186,6 @@ export default function LooseThreads({ onBack }) {
   return (
     <aside className={`lt-panel${collapsed ? ' lt-panel--collapsed' : ''}`}>
       <div className="lt-panel-header">
-        {onBack && (
-          <button className="lt-back-btn" onClick={onBack} title="Back to tasks">‹ Back</button>
-        )}
         {!collapsed && <span className="lt-panel-title">Loose Threads</span>}
         <div className="lt-panel-actions">
           {!collapsed && (


### PR DESCRIPTION
Previous fix hid the entire .container in threads mode, taking the view tab bar with it and leaving the user stuck.

New approach: wrap view content in .view-content and hide only that in threads mode — the HatBar and view tabs (Tasks / By Category / Timebox / Threads) remain visible so the user can switch to any view at any time. The LooseThreads panel also expands to full width on mobile in threads mode.

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw