### PR TITLE
Fix infinite loop in snapAroundBlockedGrid causing calendar drag freeze

### DIFF
--- a/frontend/src/components/TimeboxView.js
+++ b/frontend/src/components/TimeboxView.js
@@ -125,23 +125,28 @@ function advancePastBlockedGrid(cursor, dur, blocked) {
   return c;
 }
 
-// Hop: find nearest free slot (before or after) in grid minutes
+// Hop: find nearest free slot (before or after) in grid minutes.
+// Uses a candidate-based approach to avoid the oscillation infinite loop that
+// a naive "move until no conflict" while loop produces when two blocked slots
+// are close together (hop right → now in next block → hop left → loop).
 function snapAroundBlockedGrid(desiredMin, dur, blocked) {
-  let result = desiredMin;
-  let changed = true;
-  while (changed) {
-    changed = false;
-    for (const b of blocked) {
-      if (result < b.end && result + dur > b.start) {
-        const before = b.start - dur;
-        const after = b.end;
-        result = Math.abs(desiredMin - before) <= Math.abs(desiredMin - after) ? before : after;
-        changed = true;
-        break;
-      }
+  // Every valid placement must start just before or just after some blocked slot,
+  // or at desiredMin itself. Generate all such candidates and pick the closest free one.
+  const candidates = [desiredMin];
+  for (const b of blocked) {
+    candidates.push(b.start - dur); // just before this block
+    candidates.push(b.end);          // just after this block
+  }
+  let best = desiredMin;
+  let bestDist = Infinity;
+  for (const c of candidates) {
+    if (c < 0 || c + dur > MAX_GRID_MINS) continue;
+    if (!blocked.some(b => c < b.end && c + dur > b.start)) {
+      const dist = Math.abs(c - desiredMin);
+      if (dist < bestDist) { bestDist = dist; best = c; }
     }
   }
-  return result;
+  return best;
 }
 
 // Push: insert dragged task at desiredStart and cascade-shift overlapping tasks forward.


### PR DESCRIPTION
The while-loop approach oscillated forever when two blocked slots were close together: hop right → now inside next block → hop left → back in first block → repeat. Example: blocks [0,30] and [25,55], dragging dur=30 to pos 15: result keeps alternating between 30 and -5.

Replaced with a candidate-based scan: collect desiredMin + (start-dur, end) for every blocked slot, then pick the closest candidate that is actually free. O(n²) worst case but guaranteed to terminate with no loops.

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw