### PR TITLE
Fix homepage routing and header title in light mode

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1073,6 +1073,7 @@ def migrate_db():
 
 
 _FRONTEND_BUILD = os.path.join(BASE_DIR, '..', 'frontend', 'build')
+_HOMEPAGE_DIR   = os.path.join(BASE_DIR, '..', 'homepage')
 
 @app.route('/robots.txt')
 def robots_txt():
@@ -1092,11 +1093,14 @@ def security_txt():
     )
     return Response(body, mimetype='text/plain')
 
-@app.route('/', defaults={'path': ''})
+@app.route('/')
+def serve_homepage():
+    return send_from_directory(_HOMEPAGE_DIR, 'index.html')
+
 @app.route('/<path:path>')
 def serve_frontend(path):
     full = os.path.join(_FRONTEND_BUILD, path)
-    if path and os.path.isfile(full):
+    if os.path.isfile(full):
         return send_from_directory(_FRONTEND_BUILD, path)
     return send_from_directory(_FRONTEND_BUILD, 'index.html')
 

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -228,6 +228,16 @@
 }
 
 /* ---- Light mode ---- */
+[data-theme="light"] .header-title {
+  background: linear-gradient(135deg, #1c1209 30%, rgba(180, 70, 0, 0.9));
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+[data-theme="light"] .header-subtitle {
+  color: rgba(28, 18, 9, 0.45);
+}
+
 [data-theme="light"] .user-name {
   color: rgba(28, 18, 9, 0.75);
 }


### PR DESCRIPTION
Serve homepage/index.html at / so the marketing page loads first; the React app is served at /app and all other non-file paths. Fix the madeHappen title gradient in light mode — gradient started at white (#fff) making "made" invisible on light backgrounds.

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw