### PR TITLE
Fix homepage routing for both Flask and serve deployments

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1102,7 +1102,7 @@ def serve_frontend(path):
     full = os.path.join(_FRONTEND_BUILD, path)
     if os.path.isfile(full):
         return send_from_directory(_FRONTEND_BUILD, path)
-    return send_from_directory(_FRONTEND_BUILD, 'index.html')
+    return send_from_directory(_FRONTEND_BUILD, 'app.html')
 
 
 if __name__ == '__main__':

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,9 +15,10 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "postbuild": "mv build/index.html build/app.html && cp ../homepage/index.html build/index.html",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "serve:prod": "serve -s build -l tcp://0.0.0.0:$PORT"
+    "serve:prod": "serve build -l tcp://0.0.0.0:$PORT"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/public/homepage.html
+++ b/frontend/public/homepage.html
@@ -1,0 +1,1662 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>madeHappen — Make it happen.</title>
+  <meta name="description" content="Stop collecting tasks. Start scheduling your day. madeHappen bridges the gap between intention and action with natural language input, a Timebox calendar, Hats, and Loose Threads." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,800;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    /* ── Reset & tokens ─────────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --orange:     #f97316;
+      --amber:      #fbbf24;
+      --orange-dk:  #ea580c;
+      --bg-dark:    #141008;
+      --bg-dark2:   #1a1208;
+      --bg-warm:    #faf7f2;
+      --bg-warm2:   #f3ede4;
+      --text-dark:  #1c1209;
+      --text-mid:   rgba(28,18,9,.55);
+      --text-faint: rgba(28,18,9,.38);
+      --white:      #ffffff;
+      --grad:       linear-gradient(135deg, var(--orange), var(--amber));
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      font-size: 16px;
+      line-height: 1.6;
+      color: var(--text-dark);
+      background: var(--white);
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* ── Utilities ──────────────────────────────────────────────── */
+    .container { width: 100%; max-width: 1200px; margin: 0 auto; padding: 0 24px; }
+    .serif { font-family: 'Playfair Display', Georgia, serif; }
+    .gradient-text {
+      background: linear-gradient(135deg, var(--orange) 20%, var(--amber));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .btn {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 14px 28px; border-radius: 10px; font-size: 15px; font-weight: 600;
+      font-family: inherit; cursor: pointer; border: none; text-decoration: none;
+      transition: transform .15s, box-shadow .2s, opacity .2s;
+    }
+    .btn:hover { transform: translateY(-1px); }
+    .btn-primary {
+      background: var(--grad);
+      color: white;
+      box-shadow: 0 4px 20px rgba(249,115,22,.4);
+    }
+    .btn-primary:hover { box-shadow: 0 8px 28px rgba(249,115,22,.5); }
+    .btn-outline {
+      background: transparent;
+      color: var(--text-dark);
+      border: 2px solid rgba(28,18,9,.15);
+    }
+    .btn-outline:hover { border-color: var(--orange); color: var(--orange); }
+    .btn-outline-white {
+      background: transparent;
+      color: rgba(255,255,255,.85);
+      border: 2px solid rgba(255,255,255,.22);
+    }
+    .btn-outline-white:hover { border-color: rgba(255,255,255,.6); color: white; }
+    .chip {
+      display: inline-block;
+      background: rgba(249,115,22,.12);
+      color: var(--orange-dk);
+      border: 1px solid rgba(249,115,22,.2);
+      border-radius: 20px;
+      font-size: 11px; font-weight: 700;
+      padding: 4px 12px;
+      letter-spacing: .7px;
+      text-transform: uppercase;
+    }
+    section { padding: 96px 0; }
+
+    /* ── Navigation ─────────────────────────────────────────────── */
+    .nav {
+      position: sticky; top: 0; z-index: 100;
+      background: rgba(250,247,242,.92);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border-bottom: 1px solid rgba(28,18,9,.06);
+    }
+    .nav-inner {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 16px 0; gap: 32px;
+    }
+    .nav-logo {
+      font-size: 20px; font-weight: 800;
+      color: var(--text-dark); text-decoration: none;
+      letter-spacing: -.3px; white-space: nowrap;
+    }
+    .nav-logo span { color: var(--orange); }
+    .nav-links { display: flex; align-items: center; gap: 28px; }
+    .nav-links a {
+      color: var(--text-mid); font-size: 14px; font-weight: 500;
+      text-decoration: none; transition: color .2s;
+    }
+    .nav-links a:hover { color: var(--orange); }
+    .nav-cta { display: flex; align-items: center; gap: 12px; }
+    .nav-cta a { text-decoration: none; }
+    .nav-sign { font-size: 14px; font-weight: 500; color: var(--text-mid); text-decoration: none; }
+    .nav-sign:hover { color: var(--text-dark); }
+    .nav-btn { padding: 9px 20px; font-size: 14px; border-radius: 8px; }
+    .hamburger {
+      display: none; background: none; border: none; cursor: pointer;
+      color: var(--text-dark); padding: 4px;
+    }
+    .mobile-nav {
+      display: none;
+      flex-direction: column; gap: 4px;
+      border-top: 1px solid rgba(28,18,9,.06);
+      padding: 16px 24px 20px;
+      background: rgba(250,247,242,.98);
+    }
+    .mobile-nav a {
+      color: var(--text-mid); font-size: 15px; font-weight: 500;
+      text-decoration: none; padding: 10px 0; border-bottom: 1px solid rgba(28,18,9,.05);
+    }
+    .mobile-nav .btn { margin-top: 8px; justify-content: center; }
+    @media (max-width: 768px) {
+      .nav-links, .nav-sign, .nav-cta .btn-primary { display: none; }
+      .hamburger { display: block; }
+      .mobile-nav.open { display: flex; }
+    }
+
+    /* ── Hero ───────────────────────────────────────────────────── */
+    .hero {
+      background: var(--bg-dark);
+      padding: 100px 0 80px;
+      position: relative;
+      overflow: hidden;
+    }
+    .hero::before {
+      content: '';
+      position: absolute;
+      top: -200px; right: -200px;
+      width: 700px; height: 700px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(249,115,22,.18) 0%, transparent 65%);
+      pointer-events: none;
+    }
+    .hero::after {
+      content: '';
+      position: absolute;
+      bottom: -150px; left: -100px;
+      width: 500px; height: 500px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(251,191,36,.1) 0%, transparent 65%);
+      pointer-events: none;
+    }
+    .hero-inner {
+      display: grid; grid-template-columns: 1fr 1fr;
+      align-items: center; gap: 64px;
+      position: relative; z-index: 1;
+    }
+    .hero-eyebrow {
+      display: inline-flex; align-items: center; gap: 8px;
+      background: rgba(249,115,22,.12); border: 1px solid rgba(249,115,22,.22);
+      border-radius: 20px; padding: 6px 14px;
+      font-size: 12px; font-weight: 600; color: rgba(251,191,36,.9);
+      letter-spacing: .5px; text-transform: uppercase;
+      margin-bottom: 24px;
+    }
+    .hero-eyebrow .dot {
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--orange);
+      animation: pulse 2s ease-in-out infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50% { opacity: .6; transform: scale(.85); }
+    }
+    .hero h1 {
+      font-size: clamp(44px, 5.5vw, 68px);
+      font-weight: 800;
+      line-height: 1.06;
+      letter-spacing: -1.5px;
+      color: white;
+      margin-bottom: 6px;
+    }
+    .hero h1 .line-orange { color: var(--orange); }
+    .hero-sub {
+      font-size: 18px; font-weight: 400;
+      color: rgba(255,255,255,.5);
+      line-height: 1.65;
+      margin: 20px 0 36px;
+      max-width: 440px;
+    }
+    .hero-actions { display: flex; flex-wrap: wrap; gap: 12px; }
+    .hero-note {
+      margin-top: 20px;
+      font-size: 12px; color: rgba(255,255,255,.28);
+      display: flex; align-items: center; gap: 6px;
+    }
+    .hero-note svg { opacity: .5; }
+
+    /* App mockup */
+    .hero-mockup {
+      perspective: 1200px;
+      animation: float 5s ease-in-out infinite;
+    }
+    @keyframes float {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-8px); }
+    }
+    .mockup-frame {
+      background: rgba(255,255,255,.06);
+      backdrop-filter: blur(24px);
+      border: 1px solid rgba(255,255,255,.1);
+      border-radius: 20px;
+      padding: 0;
+      overflow: hidden;
+      box-shadow: 0 32px 80px rgba(0,0,0,.5), 0 0 0 1px rgba(255,255,255,.07);
+    }
+    .mockup-titlebar {
+      display: flex; align-items: center; gap: 8px;
+      padding: 12px 16px;
+      background: rgba(255,255,255,.04);
+      border-bottom: 1px solid rgba(255,255,255,.07);
+    }
+    .mockup-dot { width: 10px; height: 10px; border-radius: 50%; }
+    .mockup-dot.r { background: #f87171; }
+    .mockup-dot.y { background: #fbbf24; }
+    .mockup-dot.g { background: #34d399; }
+    .mockup-toolbar {
+      display: flex; align-items: center; gap: 6px;
+      margin-left: auto;
+    }
+    .mockup-tab {
+      font-size: 10px; font-weight: 600;
+      color: rgba(255,255,255,.35);
+      padding: 4px 10px; border-radius: 6px;
+      border: 1px solid transparent;
+      cursor: default;
+    }
+    .mockup-tab.active {
+      color: rgba(249,115,22,.9);
+      background: rgba(249,115,22,.12);
+      border-color: rgba(249,115,22,.2);
+    }
+    .mockup-body { padding: 16px; display: flex; flex-direction: column; gap: 8px; }
+    .mockup-input {
+      background: rgba(255,255,255,.06);
+      border: 1px solid rgba(255,255,255,.1);
+      border-radius: 9px; padding: 10px 14px;
+      font-size: 12px; color: rgba(255,255,255,.4);
+      display: flex; align-items: center; gap: 8px;
+    }
+    .mockup-input .cursor { display: inline-block; width: 1px; height: 13px; background: var(--orange); animation: blink 1.2s step-end infinite; }
+    @keyframes blink { 0%,100%{opacity:1} 50%{opacity:0} }
+    .mockup-task {
+      background: rgba(255,255,255,.07);
+      border: 1px solid rgba(255,255,255,.08);
+      border-left: 3px solid transparent;
+      border-radius: 10px; padding: 10px 14px;
+      display: flex; align-items: center; gap: 10px;
+    }
+    .mockup-task.urgent { border-left-color: #f87171; }
+    .mockup-task.today  { border-left-color: #fbbf24; }
+    .mockup-task.later  { border-left-color: rgba(255,255,255,.15); }
+    .mockup-circle {
+      width: 16px; height: 16px; border-radius: 50%;
+      border: 2px solid rgba(255,255,255,.2); flex-shrink: 0;
+    }
+    .mockup-task-text { flex: 1; }
+    .mockup-task-name { font-size: 12px; color: rgba(255,255,255,.82); font-weight: 500; }
+    .mockup-task-meta { font-size: 10px; color: rgba(255,255,255,.3); display: flex; gap: 6px; margin-top: 2px; }
+    .mockup-pill {
+      display: inline-block; padding: 1px 7px;
+      border-radius: 8px; font-size: 9px; font-weight: 600;
+    }
+    .mockup-pill.cat {
+      background: rgba(249,115,22,.15); color: rgba(249,115,22,.8);
+      border: 1px solid rgba(249,115,22,.2);
+    }
+    .mockup-pill.prio-urgent {
+      background: rgba(248,113,113,.15); color: #f87171;
+      border: 1px solid rgba(248,113,113,.2);
+    }
+    .mockup-pill.prio-today {
+      background: rgba(251,191,36,.15); color: #fbbf24;
+      border: 1px solid rgba(251,191,36,.2);
+    }
+    .mockup-hat-bar {
+      display: flex; gap: 6px; padding: 8px 0 4px; flex-wrap: wrap;
+    }
+    .mockup-hat {
+      display: inline-flex; align-items: center; gap: 5px;
+      padding: 4px 10px; border-radius: 8px;
+      font-size: 10px; font-weight: 600; color: rgba(255,255,255,.5);
+      background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.09);
+    }
+    .mockup-hat.active {
+      color: rgba(249,115,22,.9);
+      background: rgba(249,115,22,.14); border-color: rgba(249,115,22,.22);
+    }
+    .mockup-hat .stripe {
+      width: 8px; height: 8px; border-radius: 2px;
+    }
+
+    @media (max-width: 900px) {
+      .hero-inner { grid-template-columns: 1fr; gap: 48px; }
+      .hero-mockup { order: -1; }
+      .mockup-frame { max-width: 480px; margin: 0 auto; }
+      .hero h1 { font-size: clamp(38px, 8vw, 56px); }
+    }
+
+    /* ── Trust bar ──────────────────────────────────────────────── */
+    .trust-bar {
+      background: var(--bg-warm2);
+      padding: 20px 0;
+      border-top: 1px solid rgba(28,18,9,.06);
+      border-bottom: 1px solid rgba(28,18,9,.06);
+    }
+    .trust-inner {
+      display: flex; align-items: center; justify-content: center;
+      flex-wrap: wrap; gap: 32px;
+    }
+    .trust-item {
+      display: flex; align-items: center; gap: 8px;
+      font-size: 13px; font-weight: 500; color: var(--text-mid);
+    }
+    .trust-item svg { color: var(--orange); flex-shrink: 0; }
+
+    /* ── Problem ────────────────────────────────────────────────── */
+    .problem {
+      background: var(--bg-warm);
+      text-align: center;
+    }
+    .problem h2 {
+      font-size: clamp(30px, 3.5vw, 46px);
+      font-weight: 700; line-height: 1.2;
+      letter-spacing: -.5px;
+      max-width: 760px; margin: 0 auto 24px;
+    }
+    .problem h2 em { font-style: italic; color: var(--orange-dk); }
+    .problem p {
+      font-size: 17px; color: var(--text-mid);
+      max-width: 640px; margin: 0 auto;
+      line-height: 1.75;
+    }
+    .problem-stats {
+      display: flex; justify-content: center; flex-wrap: wrap; gap: 40px;
+      margin-top: 60px;
+    }
+    .stat-bubble {
+      text-align: center;
+    }
+    .stat-bubble .number {
+      font-size: 42px; font-weight: 800;
+      letter-spacing: -1px;
+      background: linear-gradient(135deg, var(--orange-dk), var(--amber));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .stat-bubble .label {
+      font-size: 13px; color: var(--text-faint);
+      font-weight: 500; margin-top: 2px;
+    }
+
+    /* ── Features ───────────────────────────────────────────────── */
+    .features { background: var(--white); }
+    .features-header {
+      text-align: center; margin-bottom: 72px;
+    }
+    .features-header h2 {
+      font-size: clamp(32px, 3.5vw, 48px);
+      font-weight: 700; letter-spacing: -.5px; margin-top: 12px;
+    }
+    .feature-pair {
+      display: grid; grid-template-columns: 1fr 1fr;
+      gap: 0; margin: 0 -24px;
+      border: 1px solid rgba(28,18,9,.07);
+      border-radius: 20px; overflow: hidden;
+      margin-bottom: 32px;
+    }
+    .feature-pair:last-child { margin-bottom: 0; }
+    .feature-text-col {
+      padding: 56px 52px;
+      background: var(--white);
+      display: flex; flex-direction: column; justify-content: center;
+    }
+    .feature-pair.dark-col .feature-text-col {
+      background: var(--bg-dark);
+    }
+    .feature-visual-col {
+      background: var(--bg-warm2);
+      display: flex; align-items: center; justify-content: center;
+      padding: 40px;
+      min-height: 360px;
+    }
+    .feature-pair.dark-col .feature-visual-col {
+      background: var(--bg-dark2);
+    }
+    .feature-pair.reverse .feature-text-col { order: 2; }
+    .feature-pair.reverse .feature-visual-col { order: 1; }
+    .feature-chip { margin-bottom: 14px; }
+    .feature-text-col h3 {
+      font-size: clamp(26px, 2.5vw, 36px);
+      font-weight: 700; letter-spacing: -.4px;
+      line-height: 1.2; margin-bottom: 16px;
+    }
+    .feature-pair.dark-col .feature-text-col h3 { color: white; }
+    .feature-text-col p {
+      font-size: 15px; line-height: 1.75; color: var(--text-mid);
+    }
+    .feature-pair.dark-col .feature-text-col p { color: rgba(255,255,255,.48); }
+    .feature-bullets {
+      list-style: none; margin-top: 20px; display: flex; flex-direction: column; gap: 8px;
+    }
+    .feature-bullets li {
+      display: flex; align-items: flex-start; gap: 10px;
+      font-size: 14px; color: var(--text-mid);
+    }
+    .feature-pair.dark-col .feature-bullets li { color: rgba(255,255,255,.45); }
+    .feature-bullets li::before {
+      content: '✓';
+      color: var(--orange);
+      font-weight: 700; flex-shrink: 0; margin-top: 1px;
+    }
+
+    @media (max-width: 860px) {
+      .feature-pair { grid-template-columns: 1fr; margin: 0; }
+      .feature-pair.reverse .feature-text-col { order: 1; }
+      .feature-pair.reverse .feature-visual-col { order: 2; }
+      .feature-visual-col { min-height: 280px; }
+      .feature-text-col { padding: 40px 32px; }
+    }
+    @media (max-width: 480px) {
+      .feature-text-col { padding: 28px 20px; }
+      .feature-visual-col { min-height: 200px; }
+    }
+
+    /* ── Feature visual: Timebox ─────────────────────────────────── */
+    .timebox-visual {
+      width: 100%; max-width: 340px;
+    }
+    .timebox-frame {
+      background: rgba(255,255,255,.06);
+      border: 1px solid rgba(255,255,255,.1);
+      border-radius: 12px; overflow: hidden;
+      box-shadow: 0 20px 50px rgba(0,0,0,.4);
+    }
+    .timebox-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 10px 14px;
+      background: rgba(255,255,255,.04);
+      border-bottom: 1px solid rgba(255,255,255,.07);
+      font-size: 11px; font-weight: 600;
+      color: rgba(255,255,255,.5);
+    }
+    .timebox-now { color: var(--orange); font-weight: 700; }
+    .timebox-grid { display: flex; flex-direction: column; }
+    .timebox-row {
+      display: flex; align-items: stretch;
+      border-bottom: 1px solid rgba(255,255,255,.04);
+    }
+    .timebox-time {
+      width: 38px; flex-shrink: 0; padding: 0 8px;
+      font-size: 9px; color: rgba(255,255,255,.2);
+      display: flex; align-items: center;
+    }
+    .timebox-slot {
+      flex: 1; min-height: 26px; padding: 4px 6px;
+      position: relative;
+    }
+    .timebox-row.now-row .timebox-slot::before {
+      content: '';
+      position: absolute;
+      left: 0; right: 0; top: 0;
+      height: 2px;
+      background: var(--orange);
+    }
+    .timebox-block {
+      background: rgba(249,115,22,.2);
+      border: 1px solid rgba(249,115,22,.35);
+      border-radius: 4px; padding: 3px 8px;
+      font-size: 9px; font-weight: 600; color: rgba(249,115,22,.9);
+    }
+    .timebox-block.green {
+      background: rgba(52,211,153,.15); border-color: rgba(52,211,153,.3);
+      color: #34d399;
+    }
+    .timebox-block.blue {
+      background: rgba(96,165,250,.15); border-color: rgba(96,165,250,.3);
+      color: #93c5fd;
+    }
+
+    /* ── Feature visual: Task Pool ───────────────────────────────── */
+    .pool-visual {
+      width: 100%; max-width: 320px;
+      background: rgba(255,255,255,.06);
+      border: 1px solid rgba(255,255,255,.1);
+      border-radius: 12px; overflow: hidden;
+      box-shadow: 0 20px 50px rgba(0,0,0,.35);
+    }
+    .pool-header {
+      padding: 10px 14px;
+      background: rgba(255,255,255,.04);
+      border-bottom: 1px solid rgba(255,255,255,.07);
+      font-size: 10px; font-weight: 600; color: rgba(255,255,255,.4);
+      text-transform: uppercase; letter-spacing: .6px;
+    }
+    .pool-input-row {
+      padding: 10px 12px;
+      background: rgba(255,255,255,.04);
+      border-bottom: 1px solid rgba(255,255,255,.06);
+      font-size: 11px; color: rgba(255,255,255,.35);
+      display: flex; align-items: center; gap: 6px;
+    }
+    .pool-tasks { padding: 8px; display: flex; flex-direction: column; gap: 5px; }
+    .pool-task {
+      display: flex; align-items: center; gap: 8px;
+      background: rgba(255,255,255,.06);
+      border: 1px solid rgba(255,255,255,.07);
+      border-left: 3px solid transparent;
+      border-radius: 8px; padding: 8px 10px;
+    }
+    .pool-task.u { border-left-color: #f87171; }
+    .pool-task.t { border-left-color: #fbbf24; }
+    .pool-task.l { border-left-color: rgba(255,255,255,.14); }
+    .pool-task-circle { width: 14px; height: 14px; border-radius: 50%; border: 2px solid rgba(255,255,255,.18); flex-shrink: 0; }
+    .pool-task-name { font-size: 11px; color: rgba(255,255,255,.78); flex: 1; }
+    .pool-task-pills { display: flex; gap: 4px; }
+    .pool-tag {
+      font-size: 8px; font-weight: 700; padding: 1px 5px;
+      border-radius: 5px;
+    }
+    .pool-tag.w { background: rgba(249,115,22,.15); color: rgba(249,115,22,.8); }
+    .pool-tag.u { background: rgba(248,113,113,.15); color: #f87171; }
+    .pool-tag.t { background: rgba(251,191,36,.15); color: #fbbf24; }
+
+    /* ── Feature visual: Hats ────────────────────────────────────── */
+    .hats-visual {
+      width: 100%; max-width: 300px;
+    }
+    .hats-bar {
+      display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px;
+    }
+    .hat-pill {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 6px 14px; border-radius: 10px;
+      font-size: 12px; font-weight: 600;
+      border: 1px solid transparent;
+      box-shadow: 0 2px 8px rgba(0,0,0,.25);
+      cursor: default;
+    }
+    .hat-pill .stripe { width: 10px; height: 10px; border-radius: 3px; flex-shrink: 0; }
+    .hat-card {
+      background: rgba(255,255,255,.07);
+      border: 1px solid rgba(255,255,255,.1);
+      border-radius: 10px; padding: 14px 16px;
+      margin-bottom: 8px;
+      font-size: 11px; color: rgba(255,255,255,.6);
+    }
+    .hat-card-title { font-size: 12px; font-weight: 600; color: rgba(255,255,255,.85); margin-bottom: 6px; }
+    .hat-card-tasks { display: flex; flex-direction: column; gap: 4px; }
+    .hat-card-task {
+      display: flex; align-items: center; gap: 6px;
+      font-size: 10px; color: rgba(255,255,255,.5);
+    }
+    .hat-card-task::before { content: '–'; color: rgba(255,255,255,.2); }
+
+    /* ── Feature visual: Loose Threads ──────────────────────────── */
+    .threads-visual {
+      width: 100%; max-width: 300px;
+      background: rgba(255,255,255,.06);
+      border: 1px solid rgba(255,255,255,.1);
+      border-radius: 12px; overflow: hidden;
+      box-shadow: 0 20px 50px rgba(0,0,0,.35);
+    }
+    .threads-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 10px 14px;
+      background: rgba(255,255,255,.04);
+      border-bottom: 1px solid rgba(255,255,255,.07);
+      font-size: 11px; font-weight: 600; color: rgba(255,255,255,.5);
+    }
+    .threads-new-btn {
+      font-size: 10px; font-weight: 700; color: var(--orange);
+      background: rgba(249,115,22,.1); border: 1px solid rgba(249,115,22,.2);
+      border-radius: 5px; padding: 2px 8px;
+    }
+    .threads-editor {
+      padding: 12px; border-bottom: 1px solid rgba(255,255,255,.06);
+    }
+    .threads-toolbar {
+      display: flex; gap: 5px; margin-bottom: 8px; flex-wrap: wrap;
+    }
+    .threads-tb-btn {
+      width: 22px; height: 22px; border-radius: 5px;
+      background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.09);
+      font-size: 9px; font-weight: 700; color: rgba(255,255,255,.45);
+      display: flex; align-items: center; justify-content: center;
+    }
+    .threads-content {
+      font-size: 11px; color: rgba(255,255,255,.6);
+      line-height: 1.6; min-height: 60px;
+    }
+    .threads-content .hl { color: rgba(249,115,22,.85); font-weight: 600; }
+    .threads-list { padding: 8px; display: flex; flex-direction: column; gap: 4px; }
+    .threads-item {
+      display: flex; align-items: center; gap: 8px;
+      padding: 7px 10px; border-radius: 7px;
+      background: rgba(255,255,255,.04);
+      border: 1px solid rgba(255,255,255,.06);
+      font-size: 10px;
+    }
+    .threads-date { color: rgba(255,255,255,.3); font-size: 9px; flex-shrink: 0; }
+    .threads-snippet { color: rgba(255,255,255,.5); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+    /* ── How it works ───────────────────────────────────────────── */
+    .how { background: var(--bg-dark); }
+    .how h2 {
+      font-size: clamp(30px, 3vw, 44px);
+      color: white; font-weight: 700; letter-spacing: -.5px;
+      text-align: center; margin-bottom: 14px;
+    }
+    .how-sub { text-align: center; color: rgba(255,255,255,.4); font-size: 17px; margin-bottom: 64px; }
+    .how-steps {
+      display: grid; grid-template-columns: repeat(3, 1fr);
+      gap: 2px; position: relative;
+    }
+    .how-steps::before {
+      content: '';
+      position: absolute;
+      top: 36px; left: calc(16.66% + 2px); right: calc(16.66% + 2px);
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--orange), transparent);
+      opacity: .4;
+    }
+    .how-step {
+      background: rgba(255,255,255,.04);
+      border: 1px solid rgba(255,255,255,.08);
+      border-radius: 16px; padding: 36px 28px 32px;
+      text-align: center;
+      transition: background .2s;
+    }
+    .how-step:hover { background: rgba(255,255,255,.07); }
+    .how-step-num {
+      width: 52px; height: 52px; border-radius: 50%;
+      background: linear-gradient(135deg, rgba(249,115,22,.25), rgba(251,191,36,.15));
+      border: 1px solid rgba(249,115,22,.3);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 20px; font-weight: 800; color: var(--orange);
+      margin: 0 auto 20px;
+    }
+    .how-step h3 {
+      font-size: 18px; font-weight: 700;
+      color: rgba(255,255,255,.9);
+      margin-bottom: 10px; letter-spacing: -.2px;
+    }
+    .how-step p {
+      font-size: 14px; color: rgba(255,255,255,.4);
+      line-height: 1.65;
+    }
+    @media (max-width: 680px) {
+      .how-steps { grid-template-columns: 1fr; }
+      .how-steps::before { display: none; }
+    }
+
+    /* ── Why madeHappen ─────────────────────────────────────────── */
+    .why { background: var(--bg-warm); }
+    .why h2 {
+      font-size: clamp(30px, 3.5vw, 44px);
+      font-weight: 700; letter-spacing: -.5px;
+      text-align: center; margin-bottom: 12px;
+    }
+    .why-sub { text-align: center; color: var(--text-mid); font-size: 16px; margin-bottom: 52px; }
+    .why-grid {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px;
+    }
+    .why-card {
+      background: var(--white);
+      border: 1px solid rgba(28,18,9,.07);
+      border-radius: 14px; padding: 24px 22px;
+      transition: border-color .2s, transform .2s, box-shadow .2s;
+    }
+    .why-card:hover {
+      border-color: rgba(249,115,22,.3);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 28px rgba(249,115,22,.1);
+    }
+    .why-icon {
+      width: 40px; height: 40px; border-radius: 10px;
+      background: rgba(249,115,22,.1); border: 1px solid rgba(249,115,22,.15);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 18px; margin-bottom: 14px;
+    }
+    .why-card h3 { font-size: 15px; font-weight: 700; margin-bottom: 8px; }
+    .why-card p { font-size: 13.5px; color: var(--text-mid); line-height: 1.65; }
+    @media (max-width: 768px) {
+      .why-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 480px) {
+      .why-grid { grid-template-columns: 1fr; }
+    }
+
+    /* ── Testimonials ───────────────────────────────────────────── */
+    .testimonials { background: var(--white); }
+    .testimonials h2 {
+      font-size: clamp(28px, 3vw, 40px);
+      font-weight: 700; letter-spacing: -.4px;
+      text-align: center; margin-bottom: 48px;
+    }
+    .testi-grid {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px;
+    }
+    .testi-card {
+      background: var(--bg-warm);
+      border: 1px solid rgba(28,18,9,.06);
+      border-radius: 16px; padding: 24px;
+    }
+    .testi-stars { font-size: 14px; margin-bottom: 14px; letter-spacing: 1px; }
+    .testi-quote {
+      font-size: 14.5px; color: var(--text-mid); line-height: 1.7;
+      font-style: italic; margin-bottom: 18px;
+    }
+    .testi-quote::before { content: '"'; }
+    .testi-quote::after  { content: '"'; }
+    .testi-author { display: flex; align-items: center; gap: 10px; }
+    .testi-avatar {
+      width: 36px; height: 36px; border-radius: 50%;
+      background: var(--grad); display: flex; align-items: center;
+      justify-content: center; font-size: 14px; font-weight: 700; color: white;
+      flex-shrink: 0;
+    }
+    .testi-name { font-size: 13px; font-weight: 700; }
+    .testi-role { font-size: 12px; color: var(--text-faint); }
+    @media (max-width: 768px) {
+      .testi-grid { grid-template-columns: 1fr; }
+    }
+
+    /* ── Pricing ────────────────────────────────────────────────── */
+    .pricing { background: var(--bg-warm); }
+    .pricing-header { text-align: center; margin-bottom: 52px; }
+    .pricing-header h2 {
+      font-size: clamp(32px, 3.5vw, 46px);
+      font-weight: 700; letter-spacing: -.5px; margin-top: 12px;
+    }
+    .pricing-header p { color: var(--text-mid); font-size: 16px; margin-top: 12px; }
+    .pricing-grid {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px;
+      max-width: 960px; margin: 0 auto;
+    }
+    .pricing-card {
+      background: var(--white);
+      border: 1px solid rgba(28,18,9,.08);
+      border-radius: 18px; padding: 32px 28px;
+      position: relative;
+      transition: transform .2s, box-shadow .2s;
+    }
+    .pricing-card:hover { transform: translateY(-4px); box-shadow: 0 16px 48px rgba(28,18,9,.1); }
+    .pricing-card.featured {
+      background: var(--bg-dark);
+      border-color: rgba(249,115,22,.3);
+      box-shadow: 0 0 0 2px rgba(249,115,22,.15), 0 16px 48px rgba(0,0,0,.3);
+    }
+    .pricing-badge {
+      position: absolute; top: -12px; left: 50%; transform: translateX(-50%);
+      background: var(--grad); color: white;
+      font-size: 10px; font-weight: 700;
+      padding: 4px 14px; border-radius: 20px;
+      white-space: nowrap; letter-spacing: .5px;
+    }
+    .pricing-tier {
+      font-size: 11px; font-weight: 700;
+      color: var(--text-faint); text-transform: uppercase; letter-spacing: .7px;
+    }
+    .pricing-card.featured .pricing-tier { color: rgba(255,255,255,.4); }
+    .pricing-price {
+      margin: 12px 0 4px;
+      display: flex; align-items: baseline; gap: 3px;
+    }
+    .price-amount {
+      font-size: 44px; font-weight: 800;
+      letter-spacing: -2px; color: var(--text-dark);
+    }
+    .pricing-card.featured .price-amount { color: white; }
+    .price-currency { font-size: 22px; font-weight: 700; color: var(--text-mid); }
+    .pricing-card.featured .price-currency { color: rgba(255,255,255,.5); }
+    .price-period { font-size: 14px; color: var(--text-faint); margin-left: 2px; }
+    .pricing-card.featured .price-period { color: rgba(255,255,255,.3); }
+    .pricing-desc { font-size: 13px; color: var(--text-faint); margin-bottom: 24px; }
+    .pricing-card.featured .pricing-desc { color: rgba(255,255,255,.38); }
+    .pricing-divider {
+      height: 1px; background: rgba(28,18,9,.07); margin-bottom: 20px;
+    }
+    .pricing-card.featured .pricing-divider { background: rgba(255,255,255,.08); }
+    .pricing-features { list-style: none; display: flex; flex-direction: column; gap: 10px; margin-bottom: 28px; }
+    .pricing-features li {
+      display: flex; align-items: flex-start; gap: 10px;
+      font-size: 13.5px; color: var(--text-mid);
+    }
+    .pricing-card.featured .pricing-features li { color: rgba(255,255,255,.55); }
+    .pricing-features li::before {
+      content: '✓'; font-weight: 700; font-size: 12px;
+      color: var(--orange); flex-shrink: 0; margin-top: 2px;
+    }
+    .pricing-btn {
+      width: 100%; padding: 13px; border-radius: 10px;
+      font-size: 14px; font-weight: 600; font-family: inherit;
+      cursor: pointer; border: none; transition: opacity .2s, transform .15s;
+      text-decoration: none; display: block; text-align: center;
+    }
+    .pricing-btn:hover { opacity: .9; transform: translateY(-1px); }
+    .pricing-btn-primary { background: var(--grad); color: white; }
+    .pricing-btn-outline {
+      background: transparent; border: 2px solid rgba(28,18,9,.12);
+      color: var(--text-dark);
+    }
+    .pricing-btn-outline:hover { border-color: var(--orange); color: var(--orange); }
+    .pricing-btn-outline-w {
+      background: transparent; border: 2px solid rgba(255,255,255,.18);
+      color: rgba(255,255,255,.8);
+    }
+    .pricing-btn-outline-w:hover { border-color: rgba(255,255,255,.5); color: white; }
+    @media (max-width: 800px) {
+      .pricing-grid { grid-template-columns: 1fr; max-width: 400px; }
+    }
+
+    /* ── CTA ────────────────────────────────────────────────────── */
+    .cta-section {
+      background: var(--bg-dark);
+      text-align: center;
+      position: relative; overflow: hidden;
+    }
+    .cta-section::before {
+      content: '';
+      position: absolute; inset: 0;
+      background: radial-gradient(ellipse 70% 60% at 50% 40%, rgba(249,115,22,.15), transparent);
+    }
+    .cta-section > .container { position: relative; z-index: 1; }
+    .cta-section h2 {
+      font-size: clamp(34px, 4vw, 54px);
+      font-weight: 800; letter-spacing: -1px; color: white; margin-bottom: 16px;
+    }
+    .cta-section p {
+      font-size: 17px; color: rgba(255,255,255,.45); max-width: 480px;
+      margin: 0 auto 40px; line-height: 1.7;
+    }
+    .cta-actions { display: flex; flex-wrap: wrap; gap: 14px; justify-content: center; }
+    .cta-note { margin-top: 20px; font-size: 12px; color: rgba(255,255,255,.25); }
+
+    /* ── Footer ─────────────────────────────────────────────────── */
+    footer {
+      background: var(--bg-dark);
+      border-top: 1px solid rgba(255,255,255,.06);
+      padding: 60px 0 32px;
+    }
+    .footer-grid {
+      display: grid; grid-template-columns: 2fr 1fr 1fr 1fr;
+      gap: 48px; margin-bottom: 48px;
+    }
+    .footer-logo {
+      font-size: 20px; font-weight: 800;
+      color: white; text-decoration: none; display: block; margin-bottom: 14px;
+    }
+    .footer-logo span { color: var(--orange); }
+    .footer-tagline {
+      font-size: 13px; color: rgba(255,255,255,.3);
+      line-height: 1.65; max-width: 260px; margin-bottom: 20px;
+    }
+    .footer-col-title {
+      font-size: 11px; font-weight: 700; color: rgba(255,255,255,.55);
+      text-transform: uppercase; letter-spacing: .7px; margin-bottom: 16px;
+    }
+    .footer-links { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+    .footer-links a {
+      font-size: 13.5px; color: rgba(255,255,255,.38);
+      text-decoration: none; transition: color .2s;
+    }
+    .footer-links a:hover { color: rgba(249,115,22,.85); }
+    .footer-bottom {
+      display: flex; align-items: center; justify-content: space-between;
+      border-top: 1px solid rgba(255,255,255,.06); padding-top: 24px;
+      flex-wrap: wrap; gap: 16px;
+    }
+    .footer-copy { font-size: 12px; color: rgba(255,255,255,.22); }
+    .footer-social { display: flex; gap: 20px; }
+    .footer-social a {
+      font-size: 12px; color: rgba(255,255,255,.28);
+      text-decoration: none; transition: color .2s;
+    }
+    .footer-social a:hover { color: rgba(249,115,22,.8); }
+    @media (max-width: 768px) {
+      .footer-grid { grid-template-columns: 1fr 1fr; gap: 32px; }
+    }
+    @media (max-width: 480px) {
+      .footer-grid { grid-template-columns: 1fr; }
+    }
+
+    /* ── Misc ───────────────────────────────────────────────────── */
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(24px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    .fade-up { animation: fadeUp .6s ease both; }
+    .fade-up.d1 { animation-delay: .1s; }
+    .fade-up.d2 { animation-delay: .2s; }
+    .fade-up.d3 { animation-delay: .3s; }
+
+    @media (max-width: 600px) {
+      section { padding: 64px 0; }
+      .btn { padding: 12px 22px; font-size: 14px; }
+    }
+    @media (max-width: 400px) {
+      section { padding: 48px 0; }
+      .container { padding: 0 16px; }
+      .pricing-card { padding: 24px 20px; }
+      .pricing-grid { max-width: 100%; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- ── Navigation ─────────────────────────────────────────────── -->
+<nav class="nav">
+  <div class="container">
+    <div class="nav-inner">
+      <a href="/" class="nav-logo">made<span>Happen</span></a>
+
+      <div class="nav-links">
+        <a href="#features">Features</a>
+        <a href="#how">How it works</a>
+        <a href="#pricing">Pricing</a>
+      </div>
+
+      <div class="nav-cta">
+        <a href="/app#login" class="nav-sign">Sign in</a>
+        <a href="/app#register" class="btn btn-primary nav-btn">Get started free</a>
+      </div>
+
+      <button class="hamburger" id="hamburger" aria-label="Menu">
+        <svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+          <line x1="3" y1="6" x2="19" y2="6"/>
+          <line x1="3" y1="11" x2="19" y2="11"/>
+          <line x1="3" y1="16" x2="19" y2="16"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+  <div class="mobile-nav" id="mobileNav">
+    <a href="#features">Features</a>
+    <a href="#how">How it works</a>
+    <a href="#pricing">Pricing</a>
+    <a href="/app#login">Sign in</a>
+    <a href="/app#register" class="btn btn-primary">Get started free</a>
+  </div>
+</nav>
+
+<!-- ── Hero ───────────────────────────────────────────────────── -->
+<section class="hero">
+  <div class="container">
+    <div class="hero-inner">
+      <!-- Left: copy -->
+      <div>
+        <div class="hero-eyebrow fade-up">
+          <span class="dot"></span>
+          Free to start · No credit card required
+        </div>
+
+        <h1 class="serif fade-up d1">
+          <span class="line-orange">Stop planning.</span><br>
+          Start doing.
+        </h1>
+
+        <p class="hero-sub fade-up d2">
+          Transform your to-do list into a scheduled day. madeHappen bridges the gap between intention and action — with natural language input, a Timebox calendar, and space for ideas that aren't ready yet.
+        </p>
+
+        <div class="hero-actions fade-up d3">
+          <a href="/app#register" class="btn btn-primary">Start free →</a>
+          <a href="#features" class="btn btn-outline-white">See how it works</a>
+        </div>
+
+        <p class="hero-note fade-up d3">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 1v6l3.5 2"/><circle cx="7" cy="7" r="6"/></svg>
+          Takes 60 seconds to set up. No onboarding required.
+        </p>
+      </div>
+
+      <!-- Right: mockup -->
+      <div class="hero-mockup fade-up d2">
+        <div class="mockup-frame">
+          <div class="mockup-titlebar">
+            <div class="mockup-dot r"></div>
+            <div class="mockup-dot y"></div>
+            <div class="mockup-dot g"></div>
+            <div class="mockup-toolbar">
+              <div class="mockup-tab active">Tasks</div>
+              <div class="mockup-tab">Timebox</div>
+              <div class="mockup-tab">Analytics</div>
+            </div>
+          </div>
+          <div class="mockup-body">
+            <div class="mockup-hat-bar">
+              <div class="mockup-hat active">
+                <span class="stripe" style="background:#f97316;"></span>
+                💼 Work
+              </div>
+              <div class="mockup-hat">
+                <span class="stripe" style="background:#34d399;"></span>
+                🏃 Health
+              </div>
+              <div class="mockup-hat">
+                <span class="stripe" style="background:#60a5fa;"></span>
+                🏠 Home
+              </div>
+            </div>
+            <div class="mockup-input">
+              email Sarah @work !urgent ^tomorrow<span class="cursor"></span>
+            </div>
+            <div class="mockup-task urgent">
+              <div class="mockup-circle"></div>
+              <div class="mockup-task-text">
+                <div class="mockup-task-name">Review Q3 proposal</div>
+                <div class="mockup-task-meta">
+                  <span class="mockup-pill cat">work</span>
+                  <span class="mockup-pill prio-urgent">urgent</span>
+                </div>
+              </div>
+            </div>
+            <div class="mockup-task today">
+              <div class="mockup-circle"></div>
+              <div class="mockup-task-text">
+                <div class="mockup-task-name">Call accountant</div>
+                <div class="mockup-task-meta">
+                  <span class="mockup-pill cat">work</span>
+                  <span class="mockup-pill prio-today">today</span>
+                </div>
+              </div>
+            </div>
+            <div class="mockup-task later">
+              <div class="mockup-circle"></div>
+              <div class="mockup-task-text">
+                <div class="mockup-task-name">Update LinkedIn bio</div>
+                <div class="mockup-task-meta">
+                  <span class="mockup-pill cat">personal</span>
+                </div>
+              </div>
+            </div>
+            <div class="mockup-task later">
+              <div class="mockup-circle"></div>
+              <div class="mockup-task-text">
+                <div class="mockup-task-name">Pick up dry cleaning ↺ weekly</div>
+                <div class="mockup-task-meta">
+                  <span class="mockup-pill cat">home</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Trust bar ─────────────────────────────────────────────── -->
+<div class="trust-bar">
+  <div class="container">
+    <div class="trust-inner">
+      <div class="trust-item">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1l1.8 3.8L14 5.7l-3 3 .7 4.3L8 11l-3.7 2 .7-4.3-3-3 4.2-.9z"/></svg>
+        Built for solopreneurs
+      </div>
+      <div class="trust-item">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1l1.8 3.8L14 5.7l-3 3 .7 4.3L8 11l-3.7 2 .7-4.3-3-3 4.2-.9z"/></svg>
+        Freelancers &amp; consultants
+      </div>
+      <div class="trust-item">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1l1.8 3.8L14 5.7l-3 3 .7 4.3L8 11l-3.7 2 .7-4.3-3-3 4.2-.9z"/></svg>
+        Professionals who own their day
+      </div>
+      <div class="trust-item">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1l1.8 3.8L14 5.7l-3 3 .7 4.3L8 11l-3.7 2 .7-4.3-3-3 4.2-.9z"/></svg>
+        Free forever · No card needed
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ── Problem ───────────────────────────────────────────────── -->
+<section class="problem">
+  <div class="container">
+    <h2 class="serif">
+      You already know what needs doing.<br>
+      The problem is <em>fitting it into your day.</em>
+    </h2>
+    <p>
+      Most task apps excel at collecting tasks — but they stop there. The average person ends their day with more tasks than they started with, not from lack of effort, but because their tools treat the to-do list as the final product. madeHappen goes further: every task gets a home in your actual day.
+    </p>
+
+    <div class="problem-stats">
+      <div class="stat-bubble">
+        <div class="number serif">41%</div>
+        <div class="label">of to-do items are never actioned*</div>
+      </div>
+      <div class="stat-bubble">
+        <div class="number serif">23 min</div>
+        <div class="label">average refocus time after interruption*</div>
+      </div>
+      <div class="stat-bubble">
+        <div class="number serif">1 tool</div>
+        <div class="label">instead of a task app + calendar</div>
+      </div>
+    </div>
+    <p style="margin-top:24px; font-size:11px; color:var(--text-faint);">* Sources: iDoneThis, University of California Irvine</p>
+  </div>
+</section>
+
+<!-- ── Features ─────────────────────────────────────────────── -->
+<section class="features" id="features">
+  <div class="container">
+    <div class="features-header">
+      <span class="chip">Built different</span>
+      <h2>Everything you need. Nothing you don't.</h2>
+    </div>
+
+    <!-- Timebox -->
+    <div class="feature-pair dark-col" id="timebox">
+      <div class="feature-text-col">
+        <div class="feature-chip"><span class="chip">The Timebox</span></div>
+        <h3 class="serif">Drag it. Drop it.<br>Done.</h3>
+        <p>A dynamic day-view calendar divided into 15-minute blocks. Tasks from your pool appear in a sidebar, ready to drag directly onto your schedule. Lock blocks to commit. An auto-schedule feature fills your day intelligently.</p>
+        <ul class="feature-bullets">
+          <li>15-minute precision calendar grid</li>
+          <li>Live "NOW" indicator as the day moves</li>
+          <li>Auto-schedule and Task Push to clear backlog</li>
+          <li>Lock blocks to protect your commitments</li>
+        </ul>
+      </div>
+      <div class="feature-visual-col">
+        <div class="timebox-visual">
+          <div class="timebox-frame">
+            <div class="timebox-header">
+              <span>Thursday, 5 Jun</span>
+              <span class="timebox-now">● NOW 10:15</span>
+            </div>
+            <div class="timebox-grid">
+              <div class="timebox-row">
+                <div class="timebox-time">9:00</div>
+                <div class="timebox-slot">
+                  <div class="timebox-block green">Morning standup</div>
+                </div>
+              </div>
+              <div class="timebox-row">
+                <div class="timebox-time">9:30</div>
+                <div class="timebox-slot">
+                  <div class="timebox-block">Review Q3 proposal</div>
+                </div>
+              </div>
+              <div class="timebox-row">
+                <div class="timebox-time">10:00</div>
+                <div class="timebox-slot">
+                  <div class="timebox-block">Review Q3 proposal</div>
+                </div>
+              </div>
+              <div class="timebox-row now-row">
+                <div class="timebox-time" style="color:var(--orange);">10:15</div>
+                <div class="timebox-slot"></div>
+              </div>
+              <div class="timebox-row">
+                <div class="timebox-time">10:30</div>
+                <div class="timebox-slot">
+                  <div class="timebox-block blue">Call accountant</div>
+                </div>
+              </div>
+              <div class="timebox-row">
+                <div class="timebox-time">11:00</div>
+                <div class="timebox-slot"></div>
+              </div>
+              <div class="timebox-row">
+                <div class="timebox-time">11:30</div>
+                <div class="timebox-slot">
+                  <div class="timebox-block">Update LinkedIn bio</div>
+                </div>
+              </div>
+              <div class="timebox-row">
+                <div class="timebox-time">12:00</div>
+                <div class="timebox-slot"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Task Pool -->
+    <div class="feature-pair reverse">
+      <div class="feature-text-col">
+        <div class="feature-chip"><span class="chip">The Task Pool</span></div>
+        <h3 class="serif">Type the way<br>you think.</h3>
+        <p>Type <code style="background:rgba(249,115,22,.1);padding:1px 6px;border-radius:4px;font-size:13px;">email boss @work !urgent ^tomorrow</code> and madeHappen intelligently parses category, priority, and due date. Quick capture, redefined.</p>
+        <ul class="feature-bullets">
+          <li>Natural language input — no forms to fill</li>
+          <li>Drag-and-drop reordering</li>
+          <li>Subtasks with visual progress bars</li>
+          <li>Recurring tasks that auto-respawn</li>
+        </ul>
+      </div>
+      <div class="feature-visual-col">
+        <div class="pool-visual">
+          <div class="pool-header">Task Pool · 4 active</div>
+          <div class="pool-input-row">
+            ✎&nbsp; email Sarah @work !urgent ^tomorrow<span style="display:inline-block;width:1px;height:12px;background:var(--orange);margin-left:1px;animation:blink 1.2s step-end infinite;"></span>
+          </div>
+          <div class="pool-tasks">
+            <div class="pool-task u">
+              <div class="pool-task-circle"></div>
+              <div class="pool-task-name">Review Q3 proposal</div>
+              <div class="pool-task-pills">
+                <span class="pool-tag w">work</span>
+                <span class="pool-tag u">urgent</span>
+              </div>
+            </div>
+            <div class="pool-task t">
+              <div class="pool-task-circle"></div>
+              <div class="pool-task-name">Call accountant</div>
+              <div class="pool-task-pills">
+                <span class="pool-tag t">today</span>
+              </div>
+            </div>
+            <div class="pool-task l">
+              <div class="pool-task-circle"></div>
+              <div class="pool-task-name">Update LinkedIn bio</div>
+              <div class="pool-task-pills">
+                <span class="pool-tag w">personal</span>
+              </div>
+            </div>
+            <div class="pool-task l">
+              <div class="pool-task-circle"></div>
+              <div class="pool-task-name">Pick up dry cleaning ↺</div>
+              <div class="pool-task-pills">
+                <span class="pool-tag w">home</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Hats -->
+    <div class="feature-pair dark-col">
+      <div class="feature-text-col">
+        <div class="feature-chip"><span class="chip">Hats</span></div>
+        <h3 class="serif">One hat for work.<br>One for life.</h3>
+        <p>Hats are madeHappen's top-level organiser — representing your major life areas. Work, Personal, Health, Family. Each has a name, emoji, and distinct colour. Filter by one Hat, or combine them for a full view of your life.</p>
+        <ul class="feature-bullets">
+          <li>Named contexts with emoji and custom colours</li>
+          <li>Single-tap filter or multi-Hat view</li>
+          <li>Drag to reorder your Hat bar</li>
+          <li>Honest reflection of how life is organised</li>
+        </ul>
+      </div>
+      <div class="feature-visual-col">
+        <div class="hats-visual">
+          <div class="hats-bar">
+            <div class="hat-pill" style="background:rgba(249,115,22,.14);border-color:rgba(249,115,22,.25);color:rgba(249,115,22,.9);">
+              <span class="stripe" style="background:#f97316;"></span>💼 Work
+            </div>
+            <div class="hat-pill" style="background:rgba(52,211,153,.1);border-color:rgba(52,211,153,.2);color:rgba(52,211,153,.8);">
+              <span class="stripe" style="background:#34d399;"></span>🏃 Health
+            </div>
+            <div class="hat-pill" style="background:rgba(96,165,250,.1);border-color:rgba(96,165,250,.2);color:rgba(96,165,250,.8);">
+              <span class="stripe" style="background:#60a5fa;"></span>🏠 Home
+            </div>
+            <div class="hat-pill" style="background:rgba(167,139,250,.1);border-color:rgba(167,139,250,.2);color:rgba(167,139,250,.8);">
+              <span class="stripe" style="background:#a78bfa;"></span>👨‍👩‍👧 Family
+            </div>
+          </div>
+          <div class="hat-card">
+            <div class="hat-card-title">💼 Work — 3 tasks</div>
+            <div class="hat-card-tasks">
+              <div class="hat-card-task">Review Q3 proposal</div>
+              <div class="hat-card-task">Call accountant</div>
+              <div class="hat-card-task">Update LinkedIn bio</div>
+            </div>
+          </div>
+          <div class="hat-card">
+            <div class="hat-card-title">🏃 Health — 2 tasks</div>
+            <div class="hat-card-tasks">
+              <div class="hat-card-task">Book physio appointment</div>
+              <div class="hat-card-task">Morning run ↺ daily</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Loose Threads -->
+    <div class="feature-pair reverse">
+      <div class="feature-text-col">
+        <div class="feature-chip"><span class="chip">Loose Threads</span></div>
+        <h3 class="serif">Ideas shouldn't become tasks<br>before they're ready.</h3>
+        <p>The gap between an idea and a task is where most apps fail. Loose Threads is a freeform notepad — capture thoughts, half-baked plans, and scattered ideas without the pressure of formalization. A digital edge for your scraps of thinking.</p>
+        <ul class="feature-bullets">
+          <li>Rich text editing with formatting tools</li>
+          <li>Always accessible alongside your tasks</li>
+          <li>Trash recovery — nothing lost forever</li>
+          <li>Tier-based thread limits (free to unlimited)</li>
+        </ul>
+      </div>
+      <div class="feature-visual-col">
+        <div class="threads-visual">
+          <div class="threads-header">
+            <span>Loose Threads</span>
+            <span class="threads-new-btn">+ New</span>
+          </div>
+          <div class="threads-editor">
+            <div class="threads-toolbar">
+              <div class="threads-tb-btn"><strong>B</strong></div>
+              <div class="threads-tb-btn" style="font-style:italic">I</div>
+              <div class="threads-tb-btn">•—</div>
+              <div class="threads-tb-btn">1.</div>
+              <div class="threads-tb-btn" style="text-decoration:line-through">S</div>
+              <div class="threads-tb-btn">A−</div>
+              <div class="threads-tb-btn">A+</div>
+            </div>
+            <div class="threads-content">
+              <span class="hl">App relaunch ideas:</span><br>
+              – Product Hunt launch in Q3<br>
+              – Outreach to freelance Twitter communities<br>
+              – Record a 2-min demo video<br>
+              <span style="color:rgba(255,255,255,.25);">Write here…</span>
+            </div>
+          </div>
+          <div class="threads-list">
+            <div class="threads-item">
+              <span class="threads-date">Today</span>
+              <span class="threads-snippet">App relaunch ideas — Product Hunt launch...</span>
+            </div>
+            <div class="threads-item">
+              <span class="threads-date">Yesterday</span>
+              <span class="threads-snippet">Client pitch notes — opening with the problem...</span>
+            </div>
+            <div class="threads-item">
+              <span class="threads-date">Mon</span>
+              <span class="threads-snippet">New project ideas — modular pricing, white label...</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<!-- ── How it works ──────────────────────────────────────────── -->
+<section class="how" id="how">
+  <div class="container">
+    <h2 class="serif">Set up in 60 seconds.</h2>
+    <p class="how-sub">No onboarding wizard. No tutorials required. Just open the app and start.</p>
+
+    <div class="how-steps">
+      <div class="how-step">
+        <div class="how-step-num">1</div>
+        <h3>Capture your tasks</h3>
+        <p>Type tasks naturally. Add categories, priorities, and due dates in one line. Or just dump the thought — you can organise it later.</p>
+      </div>
+      <div class="how-step">
+        <div class="how-step-num">2</div>
+        <h3>Schedule your day</h3>
+        <p>Drag tasks from your pool onto the Timebox. Use Auto-schedule to fill gaps automatically. Lock the blocks you're committed to.</p>
+      </div>
+      <div class="how-step">
+        <div class="how-step-num">3</div>
+        <h3>Execute &amp; iterate</h3>
+        <p>Tick tasks done, run Pomodoro sessions, track your completions. Tomorrow's plan builds on today's history — automatically.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Why madeHappen ────────────────────────────────────────── -->
+<section class="why">
+  <div class="container">
+    <span class="chip" style="display:block;text-align:center;margin-bottom:14px;">Why madeHappen</span>
+    <h2>Built for people who get things done.</h2>
+    <p class="why-sub">No team features. No complexity. Just focused tools for professionals who own their day.</p>
+
+    <div class="why-grid">
+      <div class="why-card">
+        <div class="why-icon">📅</div>
+        <h3>Time-blocking at the core</h3>
+        <p>The Timebox isn't an afterthought — it's the foundation. Drag tasks onto your calendar in 15-minute increments.</p>
+      </div>
+      <div class="why-card">
+        <div class="why-icon">🗣️</div>
+        <h3>Natural language input</h3>
+        <p>Type the way you think. madeHappen extracts categories, priorities, and due dates without a single form field.</p>
+      </div>
+      <div class="why-card">
+        <div class="why-icon">🎩</div>
+        <h3>Life organised by context</h3>
+        <p>Hats represent your major life areas. Switch between Work, Health, and Family — or combine for a complete view.</p>
+      </div>
+      <div class="why-card">
+        <div class="why-icon">🧵</div>
+        <h3>Space for unformed ideas</h3>
+        <p>Loose Threads captures thoughts that aren't ready to be tasks yet. No pressure, no structure required.</p>
+      </div>
+      <div class="why-card">
+        <div class="why-icon">🔁</div>
+        <h3>Recurring tasks that adapt</h3>
+        <p>Mark done and it auto-respawns with the next due date. Your habits stay on track without manual resets.</p>
+      </div>
+      <div class="why-card">
+        <div class="why-icon">🍅</div>
+        <h3>Focus mode built in</h3>
+        <p>Pin a Pomodoro timer to any task. Stay in flow, track your sessions, and get notified when it's time for a break.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Testimonials ──────────────────────────────────────────── -->
+<section class="testimonials">
+  <div class="container">
+    <h2 class="serif">From people who own their day.</h2>
+    <div class="testi-grid">
+      <div class="testi-card">
+        <div class="testi-stars">★★★★★</div>
+        <p class="testi-quote">I've tried Todoist, Notion, TickTick — they all let me collect tasks beautifully. madeHappen is the first one that actually makes me schedule them. That difference is everything.</p>
+        <div class="testi-author">
+          <div class="testi-avatar">A</div>
+          <div>
+            <div class="testi-name">Alex M.</div>
+            <div class="testi-role">Freelance designer</div>
+          </div>
+        </div>
+      </div>
+      <div class="testi-card">
+        <div class="testi-stars">★★★★★</div>
+        <p class="testi-quote">The natural language input alone saves me 10 minutes a day. I just type what's in my head and everything is filed correctly. The Timebox turns that list into a real plan.</p>
+        <div class="testi-author">
+          <div class="testi-avatar">S</div>
+          <div>
+            <div class="testi-name">Sophie K.</div>
+            <div class="testi-role">Consultant &amp; solopreneur</div>
+          </div>
+        </div>
+      </div>
+      <div class="testi-card">
+        <div class="testi-stars">★★★★★</div>
+        <p class="testi-quote">Loose Threads is underrated. I used to lose half my good ideas because they didn't fit into a task app structure. Now there's a place for the messy middle, and I love it.</p>
+        <div class="testi-author">
+          <div class="testi-avatar">J</div>
+          <div>
+            <div class="testi-name">James R.</div>
+            <div class="testi-role">Product manager</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Pricing ───────────────────────────────────────────────── -->
+<section class="pricing" id="pricing">
+  <div class="container">
+    <div class="pricing-header">
+      <span class="chip">Simple pricing</span>
+      <h2>Start free. Upgrade when you're ready.</h2>
+      <p>No commitments. Cancel anytime. All plans include a 14-day money-back guarantee.</p>
+    </div>
+
+    <div class="pricing-grid">
+      <!-- Free -->
+      <div class="pricing-card">
+        <div class="pricing-tier">Free</div>
+        <div class="pricing-price">
+          <span class="price-amount">$0</span>
+        </div>
+        <div class="pricing-desc">Free forever — no credit card required</div>
+        <div class="pricing-divider"></div>
+        <ul class="pricing-features">
+          <li>Up to 10 active tasks</li>
+          <li>Task Pool with natural language input</li>
+          <li>Timebox calendar</li>
+          <li>Hats (contexts)</li>
+          <li>3 Loose Threads</li>
+          <li>30-day completed history</li>
+          <li>Drag &amp; drop reordering</li>
+        </ul>
+        <a href="/app#register" class="pricing-btn pricing-btn-outline">Get started free</a>
+      </div>
+
+      <!-- Pro (featured) -->
+      <div class="pricing-card featured">
+        <div class="pricing-badge">Most Popular</div>
+        <div class="pricing-tier">Pro</div>
+        <div class="pricing-price">
+          <span class="price-currency">$</span>
+          <span class="price-amount">9</span>
+          <span class="price-period">/month</span>
+        </div>
+        <div class="pricing-desc">Everything a serious solopreneur needs</div>
+        <div class="pricing-divider"></div>
+        <ul class="pricing-features">
+          <li>Unlimited tasks</li>
+          <li>Pomodoro focus timer</li>
+          <li>Data export (CSV &amp; JSON)</li>
+          <li>10 Loose Threads</li>
+          <li>90-day task history</li>
+          <li>All Free features included</li>
+        </ul>
+        <a href="/app#register" class="pricing-btn pricing-btn-primary">Upgrade to Pro</a>
+      </div>
+
+      <!-- Premium -->
+      <div class="pricing-card">
+        <div class="pricing-tier">Premium</div>
+        <div class="pricing-price">
+          <span class="price-currency" style="color:var(--text-mid);">$</span>
+          <span class="price-amount">19</span>
+          <span class="price-period">/month</span>
+        </div>
+        <div class="pricing-desc">For power users who want every edge</div>
+        <div class="pricing-divider"></div>
+        <ul class="pricing-features">
+          <li>Everything in Pro</li>
+          <li>Rich task notes per task</li>
+          <li>Advanced analytics dashboard</li>
+          <li>Unlimited Loose Threads</li>
+          <li>Full archive — all history</li>
+          <li>Today's wins tracker</li>
+          <li>Priority support</li>
+        </ul>
+        <a href="/app#register" class="pricing-btn pricing-btn-outline">Upgrade to Premium</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── CTA ───────────────────────────────────────────────────── -->
+<section class="cta-section">
+  <div class="container">
+    <h2 class="serif">Ready to make it happen?</h2>
+    <p>Stop ending the day wondering what you actually accomplished. Start each morning with a plan. End each evening with a list of wins.</p>
+    <div class="cta-actions">
+      <a href="/app#register" class="btn btn-primary" style="font-size:16px;padding:16px 36px;">Start free today →</a>
+      <a href="#features" class="btn btn-outline-white">Explore features</a>
+    </div>
+    <p class="cta-note">Free forever · No credit card · Takes 60 seconds</p>
+  </div>
+</section>
+
+<!-- ── Footer ────────────────────────────────────────────────── -->
+<footer>
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <a href="/" class="footer-logo">made<span>Happen</span></a>
+        <p class="footer-tagline">Make it happen. A personal productivity app for solopreneurs and professionals who own their day.</p>
+        <div class="footer-social" style="margin-top:0">
+          <a href="#">Twitter</a>
+          <a href="#">LinkedIn</a>
+        </div>
+      </div>
+      <div>
+        <div class="footer-col-title">Product</div>
+        <ul class="footer-links">
+          <li><a href="#features">Features</a></li>
+          <li><a href="#pricing">Pricing</a></li>
+          <li><a href="#how">How it works</a></li>
+          <li><a href="#">Roadmap</a></li>
+        </ul>
+      </div>
+      <div>
+        <div class="footer-col-title">Company</div>
+        <ul class="footer-links">
+          <li><a href="#">About</a></li>
+          <li><a href="#">Blog</a></li>
+          <li><a href="#">Contact</a></li>
+        </ul>
+      </div>
+      <div>
+        <div class="footer-col-title">Legal</div>
+        <ul class="footer-links">
+          <li><a href="#">Privacy</a></li>
+          <li><a href="#">Terms</a></li>
+          <li><a href="#">Cookies</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="footer-bottom">
+      <p class="footer-copy">© <span id="year"></span> madeHappen. All rights reserved.</p>
+      <div class="footer-social">
+        <a href="#">Twitter</a>
+        <a href="#">LinkedIn</a>
+        <a href="#">GitHub</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<script>
+  // Year
+  document.getElementById('year').textContent = new Date().getFullYear();
+
+  // Mobile nav toggle
+  const hamburger = document.getElementById('hamburger');
+  const mobileNav = document.getElementById('mobileNav');
+  hamburger.addEventListener('click', () => {
+    mobileNav.classList.toggle('open');
+  });
+
+  // Close mobile nav on link click
+  mobileNav.querySelectorAll('a').forEach(a => {
+    a.addEventListener('click', () => mobileNav.classList.remove('open'));
+  });
+
+  // Smooth scroll for anchor links (fallback for older browsers)
+  document.querySelectorAll('a[href^="#"]').forEach(a => {
+    a.addEventListener('click', e => {
+      const id = a.getAttribute('href').slice(1);
+      if (!id) return;
+      const el = document.getElementById(id);
+      if (el) {
+        e.preventDefault();
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+
+  // Simple scroll-triggered fade-in for feature sections
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.style.opacity = '1';
+        entry.target.style.transform = 'translateY(0)';
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.feature-pair, .why-card, .testi-card, .how-step, .pricing-card').forEach(el => {
+    el.style.opacity = '0';
+    el.style.transform = 'translateY(20px)';
+    el.style.transition = 'opacity .55s ease, transform .55s ease';
+    observer.observe(el);
+  });
+</script>
+
+</body>
+</html>

--- a/frontend/public/serve.json
+++ b/frontend/public/serve.json
@@ -1,0 +1,7 @@
+{
+  "cleanUrls": false,
+  "rewrites": [
+    { "source": "/", "destination": "/index.html" },
+    { "source": "/app", "destination": "/app.html" }
+  ]
+}


### PR DESCRIPTION
- postbuild: renames build/index.html → build/app.html (React), copies homepage/index.html → build/index.html so serve's default file serving delivers the marketing page at /
- serve.json in public/: explicit rewrites so / → index.html (homepage) and /app → app.html (React); serve runs without -s flag so the rewrites take effect instead of SPA fallback overriding everything
- Flask catch-all now serves app.html for all non-root/non-file paths

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw