### PR TITLE
Add flask-limiter to root requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==3.0.0
 flask-cors==4.0.0
 Flask-SQLAlchemy==3.1.1
 Flask-JWT-Extended==4.6.0
+flask-limiter==3.5.0
 psycopg2-binary==2.9.10
 stripe==8.11.0
 python-dotenv==1.0.0


### PR DESCRIPTION
flask_limiter was used in backend/app.py but only listed in backend/requirements.txt; the nixpacks build uses the root file, causing ModuleNotFoundError on every gunicorn worker startup.

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw