### PR TITLE
Fix flask-limiter version conflict with rich==14.1.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 Flask==3.0.0
 flask-cors==4.0.0
-flask-limiter==3.5.0
+flask-limiter==4.1.1
 dateparser==1.2.2
 python-dateutil==2.9.0.post0
 Flask-SQLAlchemy==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==3.0.0
 flask-cors==4.0.0
 Flask-SQLAlchemy==3.1.1
 Flask-JWT-Extended==4.6.0
-flask-limiter==3.5.0
+flask-limiter==4.1.1
 psycopg2-binary==2.9.10
 stripe==8.11.0
 python-dotenv==1.0.0


### PR DESCRIPTION
flask-limiter==3.5.0 requires rich<14, conflicting with the pinned rich==14.1.0. Upgrade to 4.1.1 which has no rich dependency constraint.

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw