### PR TITLE
Fix postbuild: copy homepage from build/ not ../homepage/

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "postbuild": "mv build/index.html build/app.html && cp ../homepage/index.html build/index.html",
+    "postbuild": "mv build/index.html build/app.html && cp build/homepage.html build/index.html",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "serve:prod": "serve build -l tcp://0.0.0.0:$PORT"


### PR DESCRIPTION
The frontend Railway service only has the frontend/ directory in its build context, so ../homepage/ doesn't exist. homepage.html is already copied to build/ by CRA (from public/homepage.html), so use that.

https://claude.ai/code/session_01AkC2NcRncUNB9AjNUzmLJw